### PR TITLE
Add parallel classify, makedb tree output, NumPy 2 fixes, cmt2tree

### DIFF
--- a/phlame/classify.py
+++ b/phlame/classify.py
@@ -3,11 +3,11 @@
 
 """
 Created on Mon Nov  7 13:39:50 2022
+Modified for Parallel Execution 2026 by John Connolly
 
 @author: evanqu
 """
 
-#%%
 import os
 import numpy as np
 import pandas as pd
@@ -19,6 +19,8 @@ import subprocess
 import shlex 
 import contextlib
 import io
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 
 from scipy import stats
 from scipy.optimize import minimize 
@@ -27,52 +29,74 @@ from scipy.special import digamma, loggamma
 
 import phlame.helper_functions as helper
 
-#%%
-
 # Limit for exponentials to avoid overflow
 EXP_UPPER_LIMIT = np.log(np.finfo(np.float64).max) - 1.0
+
+# =====================================================================
+#  Parallel Worker Function
+# =====================================================================
+
+def fit_clade_worker(clade_args):
+    """
+    Standalone worker function to process a single clade in a separate process.
+    """
+    (clade_name, byclade_cts, mode, seed, nchain, perc_burn, 
+     max_pi, min_snps, min_prob, min_hpd, informative_pos_subset) = clade_args
+    
+    cts2model = byclade_cts[0] + byclade_cts[1]
+    total2model = byclade_cts[2] + byclade_cts[3]
+
+    # Initialize results dictionary
+    res = {
+        'name': clade_name, 'freq_raw': 0.0, 'freq_thresholded': 0.0, 'prob': -1.0, 'pi': -1.0,
+        'pi_threshold_for_presence': np.nan,
+        'hpd': np.array([-1, -1]), 'map': {}, 'chain': None,
+        'mle_cts': np.array([-1, -1]), 'mle_tot': np.array([-1, -1]),
+        'high_alpha': False, 'cts_data': byclade_cts, 'cts_pos': informative_pos_subset
+    }
+
+    # Modeling Check: minimum SNPs
+    if np.count_nonzero(cts2model) >= min_snps:
+        with np.errstate(divide='ignore', invalid='ignore'):
+            ratio_nonzero_zero = np.true_divide(np.count_nonzero(cts2model > 0),
+                                                np.count_nonzero(cts2model == 0))
+            if ratio_nonzero_zero == np.inf:
+                ratio_nonzero_zero = 1.0
         
+        # Perform Fit
+        fit = countsCSS_NEW(cts2model, total2model, seed=seed, mode=mode)
+        frequency, prob = fit.fit(max_pi=max_pi, nchain=nchain, nburn=int(perc_burn * nchain))
+
+        # Always keep the modeled abundance for downstream cutoff tuning.
+        res['freq_raw'] = frequency
+
+        # Preserve legacy thresholded abundance as a separate value.
+        if (prob > min_prob) and (fit.hpd[0] <= min_hpd) and (ratio_nonzero_zero > 0.03):
+            res['freq_thresholded'] = frequency
+        
+        res['prob'] = prob
+        res['pi'] = np.round(fit.pi, 4)
+        res['pi_threshold_for_presence'] = np.round(fit.pi, 4)
+        res['hpd'] = fit.hpd
+        res['map'] = fit.counts_MAP
+        res['chain'] = fit.chain
+        res['mle_cts'] = fit.counts_MLE
+        res['mle_tot'] = fit.total_MLE
+        res['high_alpha'] = fit.measured_alpha > 100000
+
+    return res
+
+# =====================================================================
+#  Main Controller Class
+# =====================================================================
+
 class Classify:
-    '''
-    Main controller of the classify step.
-    
-    Args:
-    path_to_cts_file (str): Path to PhLAMe counts file.\n
-    
-    path_to_classifier (str): Path to PhLAMe classifier file.
-    level_input (str): Path to file defining the phylogenetic level.
-    to type strains at. This file can either list clade names as 
-    they appear in the PhLAMe classifier OR custom group genomes 
-    into clades in a 2 column .tsv {genomeID, cladeID}.\n
-    
-    path_to_frequencies (str): Path to output frequencies file.\n
-    
-    path_to_data (str, optional): If True, outputs a data file 
-    with counts and modeling information at the defined level.
-    Defaults to False.\n
-    
-    max_perc_diff (TYPE, optional): Maximum . Defaults to 0.3.\n
-    
-    max_snp_diff (TYPE, optional): If True, . Defaults to False.\n
-    
-    min_snps (int, optional): Minimum number of csSNPs with >0 counts
-    to call a lineage as present. Defaults to 10.\n
-    
-    '''
-    
-    def __init__(self,
-                 path_to_bam,
-                 path_to_classifier,
-                 ref_file,
-                 path_to_frequencies,
-                 level_input=False,
-                 path_to_data=False,
-                 mode='mle',
+    def __init__(self, path_to_bam, path_to_classifier, ref_file, path_to_frequencies,
+                 level_input=False, path_to_data=False, mode='mle',
                  min_snps=10, max_pi=0.3, min_prob=0.5, min_hpd=0.1,
                  nchain=10000, perc_burn=0.1, seed=False, verbose=True):
 
         self.__path_to_bam_file = path_to_bam
-
         self.__ref_file = ref_file
         self.__classifier_file = path_to_classifier
         self.__levels_input = level_input
@@ -83,1050 +107,448 @@ class Classify:
         self.min_snps = min_snps
         self.min_prob = min_prob
         self.min_hpd = min_hpd
-
         self.nchain = nchain
         self.perc_burn = perc_burn
         self.seed = seed
-
         self.mode = mode
 
     def main(self):
-        
-        # =====================================================================
-        #  Load Data
-        # =====================================================================
         print("Reading in file(s)...")
-
         self.file_check()
-
         self.load_classifier()
-
         self.load_data()
     
-        # =====================================================================
-        #  Sort through counts mat to grab just the relevant positions
-        # =====================================================================
         print("Sorting counts information...")
-        
         self.index_counts()
-        
         self.get_allele_counts()
-
         self.get_counts_alpha()
 
-        # =====================================================================
-        #  Calculate & Save frequencies
-        # =====================================================================
-        print("Modeling counts...")
-        
+        print("Modeling counts in parallel...")
         self.calc_frequencies()
-            
         self.save_frequencies()
 
-
     def file_check(self):
-
-        # Check that bam file exists
         if not os.path.exists(self.__path_to_bam_file):
             raise FileNotFoundError(f"Cannot find the file: {self.__path_to_bam_file} !")
-        
         if not os.path.exists(self.__ref_file):
             raise FileNotFoundError(f"Cannot find the reference genome file: {self.__ref_file} !")
 
-
-    def get_positions(self,
-                      output_chrpos_file):
-        ''' From a classifier object, produce a samtools compatible list of positions
-            that are informative to calling clades
-
-        Args:
-            path_to_classifier (str): Single path to input classifier file, or path 
-                                    to directory with multiple classifier files.\n
-            output_allpos_file (str): Path to file giving positions as they appear in
-                                    the classifier object (NOT samtools compatible).\n 
-            output_chrpos_file (str): Path to samtools compatible list of positions.
-            refgenome_folder (str): DESCRIPTION.
-
-        Raises:
-            Exception: DESCRIPTION.
-
-        Returns:
-            None.
-
-        '''
+    def get_positions(self, output_chrpos_file):
         cat_pos = np.array([], dtype=np.int32)
         chr_starts, _, scaf_names = helper.genomestats(self.__ref_file)
         
         path_to_cfrs_ls = []
-        # Parse whether file or directory of files
         if os.path.isdir(self.__classifier_file):
-            
             for filename in os.listdir(self.__classifier_file):
-                
                 if filename.endswith('.classifier'):
-                    path_to_cfrs_ls.append(self.__classifier_file+'/'+filename)
+                    path_to_cfrs_ls.append(os.path.join(self.__classifier_file, filename))
         else:
             path_to_cfrs_ls.append(self.__classifier_file)
             
-        
-        # Get data from each classifier
         for cfr in path_to_cfrs_ls:
-            
-            with gzip.open(cfr,'rb') as f:
+            with gzip.open(cfr, 'rb') as f:
                 csSNPs = pickle.load(f)
-                                
                 pos = csSNPs['cssnp_pos']
-                cat_pos = np.concatenate([pos,cat_pos])
+                cat_pos = np.concatenate([pos, cat_pos])
 
         allpos = np.unique(np.sort(cat_pos))
-        
         print(f"{len(allpos)} informative positions found across {len(path_to_cfrs_ls)} classifier(s)")
         
         chr_pos = helper.p2chrpos(allpos, chr_starts)
         chr_names = np.array([scaf_names[i-1] for i in chr_pos[:,0]])
-        chr_pos_final = np.vstack((chr_names,chr_pos[:,1])).T
-        
-        #save as samtools compatible txt file
-        # np.savetxt(output_allpos_file, allpos, fmt='%i')
+        chr_pos_final = np.vstack((chr_names, chr_pos[:,1])).T
         np.savetxt(output_chrpos_file, chr_pos_final, delimiter='\t', fmt='%s')
-        
-        return
-
 
     def load_classifier(self):
-        '''
-        Load in classifier and level information
-        '''
-        
         self.classifier = helper.PhlameClassifier.read_file(self.__classifier_file)
-        
         if self.__levels_input:
-            self.mylevel = PhyloLevel(self.__levels_input, 
-                                      self.classifier.clades, 
-                                      self.classifier.clade_names)
-            
-            # Grab just information for the specific level
+            self.mylevel = PhyloLevel(self.__levels_input, self.classifier.clades, self.classifier.clade_names)
             self.level_cfr = self.classifier.grab_level(self.mylevel)
-        
         else:
             self.level_cfr = self.classifier
 
     def load_data(self):
-
         with tempfile.TemporaryDirectory() as temp_dir:
-        
             chrpositions_file = shlex.quote(os.path.join(temp_dir, 'chrpositions.txt'))
             pileup_file = shlex.quote(os.path.join(temp_dir, 'temp.pileup'))
-            
             self.get_positions(chrpositions_file)
             
-            print("Running samtools mpileup at informative positions...")
-            print(f"samtools mpileup -q30 -x -s -O -d3000 "+ \
-                           f"-l {chrpositions_file} "+ \
-                           f"{shlex.quote(self.__ref_file)} "+ \
-                           f"{shlex.quote(self.__path_to_bam_file)} > {pileup_file}")
-            
-            subprocess.run(f"samtools mpileup -q30 -x -s -O -d3000 "+ \
-                           f"-l {chrpositions_file} "+ \
-                           f"-f {shlex.quote(self.__ref_file)} "+ \
+            print("Running samtools mpileup...")
+            subprocess.run(f"samtools mpileup -q30 -x -s -O -d3000 " +
+                           f"-l {chrpositions_file} " +
+                           f"-f {shlex.quote(self.__ref_file)} " +
                            f"{shlex.quote(self.__path_to_bam_file)} > {pileup_file}", shell=True)
-            # pileup_file.flush()  # Ensure data is written
 
-            self.countsmat = helper.CountsMat(pileup_file,
-                                            self.__ref_file,
-                                            self.__classifier_file)
+            self.countsmat = helper.CountsMat(pileup_file, self.__ref_file, self.__classifier_file)
             self.countsmat.main()
 
     def index_counts(self):
-        '''
-        Make structures to index through counts array.
-        '''
-        
-        # Informative positions for this level
-        # Note this will be > true pos because of pos with multiple alleles
         informative_bool = np.nonzero(self.level_cfr.csSNPs)[0]
         self.informative_pos = self.level_cfr.csSNP_pos[informative_bool]
+        self.informative_pos_idx = np.arange(0, len(self.countsmat.pos))[np.isin(self.countsmat.pos, self.informative_pos)][informative_bool]
         
-        # Corresponding index on counts mat
-        self.informative_pos_idx = np.arange(0,len(self.countsmat.pos))\
-            [np.isin(self.countsmat.pos,self.informative_pos)]\
-                [informative_bool]
+        if np.sum(np.isin(self.countsmat.pos, self.informative_pos)) != len(np.unique(self.informative_pos)):
+            raise Exception('Counts and classifier positions do not match.')
 
-        # informative_pos_idx = np.arange(0,len(pos))[np.sum(csSNPs,1)>0]
-        counts_CSS_bool = np.isin(self.countsmat.pos,self.informative_pos)
-
-        # Check that all positions are accounted for
-        if np.sum(counts_CSS_bool) != len(np.unique(self.informative_pos)):
-            raise Exception('Counts and classifier positions do not match. ',
-                            'Check that reference genomes are same.')
-    
     def get_allele_counts(self):
-        
-        np.seterr(divide='ignore', invalid='ignore') #ignore divide by 0 warnings
-        
+        np.seterr(divide='ignore', invalid='ignore')
         counts = self.countsmat.counts
         counts_idx = self.informative_pos_idx
         alleles = self.level_cfr.alleles
         
-        #Initialize data structures
-        cts_f = np.zeros(len(counts_idx))
-        cts_r = np.zeros(len(counts_idx))
-        tot_f = np.zeros(len(counts_idx))
-        tot_r = np.zeros(len(counts_idx))
+        cts_f, cts_r = np.zeros(len(counts_idx)), np.zeros(len(counts_idx))
+        tot_f, tot_r = np.zeros(len(counts_idx)), np.zeros(len(counts_idx))
         
         for i, p in enumerate(self.informative_pos):
+            cts_f[i] = counts[counts_idx[i], int(alleles[i]-1)]
+            cts_r[i] = counts[counts_idx[i], int(alleles[i]+3)]
+            tot_f[i] = np.sum(counts[counts_idx[i], :4])
+            tot_r[i] = np.sum(counts[counts_idx[i], 4:])
             
-            # -1 +3 is to convert 01234 NATCG to index 
-            cts_f[i] = counts[counts_idx[i],
-                              int(alleles[i]-1)]
-            
-            cts_r[i] = counts[counts_idx[i],
-                              int(alleles[i]+3)]
-            
-            tot_f[i] = np.sum(counts[counts_idx[i],:4])
-            tot_r[i] = np.sum(counts[counts_idx[i],4:])
-            
-        self.allele_counts = tuple([cts_f,cts_r,tot_f,tot_r])
+        self.allele_counts = (cts_f, cts_r, tot_f, tot_r)
 
     def get_counts_alpha(self):
-        '''
-        Get overdispersion metric (alpha) across all informative positions.
-        '''
-        
-        counts = self.countsmat.counts
-        counts_sum = np.sum(counts, axis=1)
-
-        self.measured_alpha = np.mean(counts_sum)**2/max(1e-6,np.var(counts_sum)-np.mean(counts_sum))
+        counts_sum = np.sum(self.countsmat.counts, axis=1)
+        self.measured_alpha = np.mean(counts_sum)**2 / max(1e-6, np.var(counts_sum) - np.mean(counts_sum))
     
     def calc_frequencies(self):
-
         clade_names = self.level_cfr.clade_names
         nclades = len(clade_names)
         
-        frequencies = np.zeros(nclades)
-    
-        save_cts = []
-        save_cts_pos = []
-        save_chain = []
-        save_hpd = []
-        save_cts_map = []
-
-        save_prob=np.full(nclades,-1,dtype=np.float64)
-        save_pi=np.full(nclades,-1,dtype=np.float64)
-        save_counts_MLE=np.full((nclades,2),-1,dtype=np.float64)
-        save_total_MLE=np.full((nclades,2),-1,dtype=np.float64)
-
-        save_flag_highalpha = np.full(nclades,False,dtype=bool)
-        save_flag_map_mle_diff = np.full(nclades,False,dtype=bool)
-
-        # Reshape data to group by clade
-        for c in range(len(clade_names)):
+        # Prepare parallel tasks
+        tasks = []
+        for c in range(nclades):
+            byclade_cts = self.reshape_byclade(self.allele_counts, self.level_cfr.allele_cidx, c)
+            byclade_pos = self.informative_pos[np.where(self.level_cfr.allele_cidx == c)]
             
-            byclade_cts = self.reshape_byclade(self.allele_counts,
-                                               self.level_cfr.allele_cidx, c)
-            
-            byclade_cts_pos = self.informative_pos[np.where(self.level_cfr.allele_cidx == c)]
-    
-            cts2model = byclade_cts[0] + byclade_cts[1]
-            total2model = byclade_cts[2] + byclade_cts[3]
+            task_args = (
+                clade_names[c], byclade_cts, self.mode, self.seed, 
+                self.nchain, self.perc_burn, self.max_pi, self.min_snps, 
+                self.min_prob, self.min_hpd, byclade_pos
+            )
+            tasks.append(task_args)
 
-            # To model, a clade must have a nonzero_zero ratio > 0.03 
-            # and at least 10 SNPs with nonzero counts
-            if (np.count_nonzero(cts2model) >= self.min_snps):
+        # Execute modeling in parallel
+        # Note: Using all available CPUs. You can set max_workers=X to limit cores.
+        with ProcessPoolExecutor() as executor:
+            results = list(executor.map(fit_clade_worker, tasks))
 
-                with np.errstate(divide='ignore', invalid='ignore'):
-                    ratio_nonzero_zero = np.true_divide(np.count_nonzero(cts2model>0),
-                                                        np.count_nonzero(cts2model==0))
-                    if ratio_nonzero_zero == np.inf:
-                        ratio_nonzero_zero = 1.0
-                    
-                                
-                print(f"Fit results for clade: {clade_names[c]}")
-                
-                fit = countsCSS_NEW(cts2model,
-                                    total2model,
-                                    seed=self.seed,
-                                    mode=self.mode)
-                                                    
-                frequency, prob = fit.fit(max_pi = self.max_pi,
-                                          nchain = self.nchain,
-                                          nburn = int(self.perc_burn*self.nchain))
+        # Reassemble results
+        freq_raw_list, freq_thresholded_list, prob_list, pi_list, pi_thresh_list = [], [], [], [], []
+        save_cts, save_cts_pos, save_chain, save_hpd, save_cts_map = [], [], [], [], []
+        save_counts_MLE = np.zeros((nclades, 2))
+        save_total_MLE = np.zeros((nclades, 2))
 
-                # print(f"MLE fit: cts lambda={fit.counts_MLE[0]:.2f} cts pi={fit.counts_MLE[1]:.2f}")
-                # print(f"total lambda={fit.total_MLE[0]:.2f} total pi={fit.total_MLE[1]:.2f}")
-                # print(f"HPD interval: {fit.hpd[0]:.2f}-{fit.hpd[1]:.2f}")
-                
-                # Only count clades if pass probability and HPD thresholds
-                if (prob > self.min_prob) & \
-                    (fit.hpd[0] <= self.min_hpd) & \
-                        (ratio_nonzero_zero > 0.03):
+        for i, res in enumerate(results):
+            freq_raw_list.append(res['freq_raw'])
+            freq_thresholded_list.append(res['freq_thresholded'])
+            prob_list.append(res['prob'])
+            pi_list.append(res['pi'])
+            pi_thresh_list.append(res['pi_threshold_for_presence'])
+            save_hpd.append(res['hpd'])
+            save_cts_map.append(res['map'])
+            save_chain.append(res['chain'])
+            save_counts_MLE[i] = res['mle_cts']
+            save_total_MLE[i] = res['mle_tot']
+            save_cts.append(res['cts_data'])
+            save_cts_pos.append(res['cts_pos'])
 
-                    frequencies[c] = fit.frequency
-                    
-                if fit.measured_alpha > 100000:
-                    save_flag_highalpha[c] = True
+        self.frequencies = pd.DataFrame({
+            'Relative abundance pre-threshold': freq_raw_list,
+            'Relative abundance': freq_thresholded_list,
+            'DVb': pi_list,
+            'Pi threshold for presence (max_pi > this)': pi_thresh_list,
+            'Probability score': prob_list
+        }, index=clade_names)
 
-                # Save fit information
-                save_hpd.append(fit.hpd)
-                save_cts_map.append(fit.counts_MAP)
-                save_counts_MLE[c] = fit.counts_MLE
-                save_total_MLE[c] = fit.total_MLE
-                save_prob[c] = prob
-                save_pi[c] = np.round(fit.pi,4)
-                # print(fit.counts_MAP.keys())
-                
-                save_chain.append(fit.chain)
-
-            # Otherwise is zero
-            else:
-                print(f"Clade: {clade_names[c]} ",
-                      "does not have not enough SNPs to model")
-                # save_chain.append({})
-                save_hpd.append(np.array((-1,-1)))
-                save_cts_map.append({})
-
-                save_chain.append(None)
-
-            # Save counts data
-            save_cts.append( byclade_cts )
-            save_cts_pos.append( byclade_cts_pos )
-            
-        frequencies_df = pd.DataFrame({'Relative abundance':frequencies,
-                                       'DVb':save_pi,
-                                       'Probability score':save_prob},
-                                      index=self.level_cfr.clade_names)
-
-        self.frequencies = frequencies_df
-        self.data = {'clade_counts':save_cts,
-                     'clade_counts_pos':save_cts_pos}
-        self.fit_info = {'counts_MLE': save_counts_MLE,
-                         'total_MLE':save_total_MLE,
-                         'counts_MAP':save_cts_map,
-                         'chain':save_chain,
-                         'prob':save_prob,
-                         'hpd':save_hpd,
-                         'mode':self.mode,
-                         'coverage':self.countsmat.coverage}
+        self.data = {'clade_counts': save_cts, 'clade_counts_pos': save_cts_pos}
+        self.fit_info = {
+            'counts_MLE': save_counts_MLE, 'total_MLE': save_total_MLE,
+            'counts_MAP': save_cts_map, 'chain': save_chain,
+            'prob': np.array(prob_list), 'hpd': save_hpd,
+            'mode': self.mode, 'coverage': self.countsmat.coverage
+        }
     
     def save_frequencies(self):
-        '''
-        Write frequencies and data to files.
-        '''        
-        
-        # Save frequencies
         self.frequencies.to_csv(self.__output_freqs_file, sep=',')
-        
-        # Save data and fit info
         if self.__output_data_file:
-            
-            with gzip.open(self.__output_data_file,'wb') as f:
-                
-                pickle.dump([self.data, self.fit_info],f)
+            with gzip.open(self.__output_data_file, 'wb') as f:
+                pickle.dump([self.data, self.fit_info], f)
 
     @staticmethod
     def reshape_byclade(allele_counts, clade_idxs, i):
-        '''
-        Grab only allele counts belonging to a certain clade (i)
-        '''
-        
         clade_cts_f = allele_counts[0][np.where(clade_idxs==i)]
         clade_cts_r = allele_counts[1][np.where(clade_idxs==i)]
         clade_tot_f = allele_counts[2][np.where(clade_idxs==i)]
         clade_tot_r = allele_counts[3][np.where(clade_idxs==i)]
+        return (clade_cts_f, clade_cts_r, clade_tot_f, clade_tot_r)
 
-        
-        return tuple([clade_cts_f,
-                      clade_cts_r,
-                      clade_tot_f,
-                      clade_tot_r])
+# =====================================================================
+#  Statistical Modeling Class
+# =====================================================================
 
 class countsCSS_NEW:
-    '''
-    Hold and model counts data covering a single set of cluster-specific SNPs.
-    '''
-    
-    def __init__(self, 
-                 counts, total_counts,
-                 force_alpha=False,
-                 prior=True,
-                 prior_strength=20,
-                 seed=False,
-                 mode='bayesian'):
-        
+    def __init__(self, counts, total_counts, force_alpha=False, prior=True, prior_strength=20, seed=False, mode='bayesian'):
         self.counts = counts
         self.total_counts = total_counts
-                
-        # Maximum Likelihood fit
+        self.force_alpha = force_alpha
+        self.prior_strength = prior_strength
+        self.seed = seed
+        self.mode = mode
+
+        # MLE for initialization
         with contextlib.redirect_stdout(io.StringIO()):
             self.counts_MLE = self.zip_fit_mle(self.counts)
             self.total_MLE = self.zip_fit_mle(self.total_counts)
         
-        self.force_alpha = force_alpha
-
-        self.prior_strength = prior_strength
-        
-        self.seed = seed
-
-        self.mode = mode
-
-        # Set hyperparameters
         if force_alpha:
             self.measured_alpha = force_alpha
-            
         else:
-            self.measured_alpha = np.mean(self.total_counts)**2/max(1e-6,np.var(self.total_counts)-np.mean(self.total_counts))
+            self.measured_alpha = np.mean(self.total_counts)**2 / max(1e-6, np.var(self.total_counts) - np.mean(self.total_counts))
 
-        m = self.prior_strength # Prior strength; higher values = stronger prior
+        m = self.prior_strength
         logp = m * digamma(self.measured_alpha)
-        v = 0; s = 0
-        self.params = [m, logp, v, s]
+        self.params = [m, logp, 0, 0] if prior else [0, np.log(1), 0, 0]
 
-        if not prior:
-            self.params = [0, np.log(1), 0, 0]
-
-    def fit(self, max_pi,
-            nchain=10000, 
-            nburn=500,
-            interval_size=0.95,
-            subsample=True
-            ):
-        '''
-        Fit counts data to model.
-        '''
+    def fit(self, max_pi, nchain=10000, nburn=500, interval_size=0.95, subsample=True):
+        if self.seed: np.random.seed(self.seed)
         
-        if self.seed:
-            np.random.seed(self.seed)
-        
-        # =====================================================================
-        #  Maximum Likelihood
-        # =====================================================================
         if self.mode == 'mle':
-        
             lambda_MLE, pi_MLE = self.ZINB_MLE()
-
-            self.counts_MLE = (pi_MLE,lambda_MLE)
-            
-            self.hpd = np.array([-1,-1])
-
+            self.counts_MLE = (pi_MLE, lambda_MLE)
+            self.hpd = np.array([-1, -1])
             self.counts_MAP = {}
-
             self.prob = int(pi_MLE < max_pi)
-
-            self.frequency = (lambda_MLE/self.total_MLE[0])
-
+            self.frequency = (lambda_MLE / self.total_MLE[0])
             self.pi = pi_MLE
-
             self.chain = None
 
-
-        # =====================================================================
-        #  Gibbs sampling
-        # =====================================================================
         elif self.mode == 'bayesian':
-
             lambda_MLE, pi_MLE = self.ZINB_MLE()
-
-            self.counts_MLE = (pi_MLE,lambda_MLE)
-
-            if subsample & (len(self.counts) > 1000):
+            self.counts_MLE = (pi_MLE, lambda_MLE)
+            if subsample and (len(self.counts) > 1000):
                 self.counts, self.total_counts = self.subsample_positions(1000)
-                
+            
             try:
-                param_chains, lv_chains = self.ZINB_gibbs_sampler(nchain,
-                                                                nburn)
-                
+                param_chains, _ = self.ZINB_gibbs_sampler(nchain, nburn)
             except RuntimeError:
-                
-                print('Loglikelihood became too low and triggered an overflow error.\
-                    Randomly subsampling positions and trying again...')
-                
-                # subsample_idx = np.random.choice(np.arange(0,len(self.counts)),
-                #                                 int(len(self.counts)/2))
-                
-                # self.counts = self.counts[subsample_idx]
-                # self.total_counts = self.total_counts[subsample_idx]
-
                 self.counts, self.total_counts = self.subsample_positions(int(len(self.counts)/2))
-                
-                param_chains, lv_chains = self.ZINB_gibbs_sampler(nchain,
-                                                                nburn)
+                param_chains, _ = self.ZINB_gibbs_sampler(nchain, nburn)
 
-            
-            self.chain = {'pi':param_chains[:,0],
-                        'a':param_chains[:,1],
-                        'b':param_chains[:,2]}
-
-            self.counts_MAP = {'pi':self.calc_MAP(self.chain['pi']),
-                            'a':self.calc_MAP(self.chain['a']),
-                            'b':self.calc_MAP(self.chain['b'])}
-            
+            self.chain = {'pi': param_chains[:, 0], 'a': param_chains[:, 1], 'b': param_chains[:, 2]}
+            self.counts_MAP = {k: self.calc_MAP(v) for k, v in self.chain.items()}
             self.hpd = self.get_hpd(self.chain['pi'], interval_size)
-            self.prob = np.sum(self.chain['pi'] < max_pi)/len(self.chain['pi'])
+            self.prob = np.sum(self.chain['pi'] < max_pi) / len(self.chain['pi'])
+            self.frequency = ((self.counts_MAP['a'] / self.counts_MAP['b']) / self.total_MLE[0])
+            self.pi = self.counts_MAP['pi']
 
-            self.frequency = ((self.counts_MAP['a']/self.counts_MAP['b'])/self.total_MLE[0])
-
-            self.pi = self.calc_MAP(self.chain['pi'])
-
-        else:
-            raise ValueError('Mode must be either "mle" or "bayesian"')
-            
         return self.frequency, self.prob
 
     def ZINB_MLE(self):
-        
         init = (np.log(np.mean(self.counts)), 0)
-        result = minimize(self.zinb_nloglike, init, 
-                          args=(self.counts,self.measured_alpha,))
-
-        # Output the optimized parameters
-        lambda_MLE, pi_MLE = result.x
-        # lambda_ests.append(np.exp(lambda_est))
-        # pi_ests.append(1 / (1 + np.exp(-pi_est)))
-        # Convert back to bounded values
-        return np.exp(lambda_MLE), 1 / (1 + np.exp(-pi_MLE))
+        result = minimize(self.zinb_nloglike, init, args=(self.counts, self.measured_alpha,))
+        return np.exp(result.x[0]), 1 / (1 + np.exp(-result.x[1]))
 
     def ZINB_gibbs_sampler(self, nchain, nburn):
-        '''
-        Gibbs sampling from the following hierarchical model: 
-        '''
         nparams = 3 
         npts = len(self.counts)    
         m, logp, v, s = self.params
-        
         zero_idx = np.nonzero(self.counts == 0)[0]
         nonzero_idx = np.nonzero(self.counts)[0]    
         
-        # Initialize chain
         param_inits, latent_var_inits = self.initialize_chain()
-        
         param_samples = np.zeros([nchain, nparams])
         param_samples[0] = param_inits
         latent_var_samples = np.zeros([nchain, 2, npts])
         latent_var_samples[0] = latent_var_inits
     
         for i in range(nchain-1):
-
-            # sample from 𝜆i|...        
-            lambda_i = self.sample_lambda_i_conditional(param_samples[i,1], 
-                                                       param_samples[i,2], 
-                                                       self.counts, 
-                                                       latent_var_samples[i,1])
-            
-            # sample from ri|...
-            ri = self.sample_ri_conditional(npts, param_samples[i,0], lambda_i, 
-                                           zero_idx, nonzero_idx)
-            
-            # sample from pi|...
+            lambda_i = self.sample_lambda_i_conditional(param_samples[i,1], param_samples[i,2], self.counts, latent_var_samples[i,1])
+            ri = self.sample_ri_conditional(npts, param_samples[i,0], lambda_i, zero_idx, nonzero_idx)
             pi = self.sample_p_conditional(ri, npts)
+            b = max(1e-6, self.sample_b_conditional(param_samples[i,1], v, s, lambda_i, npts))
+            a = self.sample_a_conditional_gp([lambda_i, b, v, m, logp], param_samples[i,1])[-1]
             
-            # sample from b|...
-            b = max(1e-6,self.sample_b_conditional(param_samples[i,1], v, s, lambda_i, npts))
-            
-            # sample from a|...
-            a_chain = self.sample_a_conditional_gp([lambda_i,b,v,m,logp], 
-                                                    param_samples[i,1])
-            a = a_chain[-1]
-            
-            param_samples[i+1] = np.array([pi, a, b])
-            latent_var_samples[i+1] = np.array([lambda_i,ri])
+            param_samples[i+1] = [pi, a, b]
+            latent_var_samples[i+1] = [lambda_i, ri]
         
-        # Convert pi into percent zero-inflated
         param_samples[:,0] = (1 - param_samples[:,0])
-        
         return param_samples, latent_var_samples
     
     def initialize_chain(self):
-        '''
-        Initialize parameters and latent variables for Gibbs sampling.
-        '''
-        
         counts_mean = self.counts.mean()
-        
-        pi_init = min(1 - ((self.counts == 0).mean() - stats.poisson.pmf(0, counts_mean)),0.99)
+        pi_init = min(1 - ((self.counts == 0).mean() - stats.poisson.pmf(0, counts_mean)), 0.99)
         a_init = self.measured_alpha
-        b_init = a_init/counts_mean
-        
-        param_inits = np.array([pi_init, a_init, b_init])
-        
-        
+        b_init = a_init / counts_mean
         ri_init = np.int64(self.counts > 0)
-        predicted_zeros = (1/(1+self.measured_alpha*counts_mean))**(1/self.measured_alpha)
-        ri_init[ri_init == 0] = stats.bernoulli.rvs(predicted_zeros, size=np.sum(ri_init==0))
-        lambda_init = [self.counts.mean()]*len(self.counts)
-
-        latent_var_inits = np.array([lambda_init,ri_init])
-        
-        return param_inits, latent_var_inits
+        return [pi_init, a_init, b_init], [np.full(len(self.counts), counts_mean), ri_init]
 
     def subsample_positions(self, n):
-        '''
-        Subsample n positions from the counts data.
-        '''
-        
-        idx = np.random.choice(np.arange(0,len(self.counts)), n)
-        
+        idx = np.random.choice(np.arange(0, len(self.counts)), n)
         return self.counts[idx], self.total_counts[idx]
         
     def zip_fit_mle(self, cts):
-        
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             model = ZeroInflatedPoisson(cts)
             fit = model.fit()
-            pi, lambda_ = fit.params
-        
-        # return lambda_, pi
-            # CI_pi, CI_lambda_ = fit.conf_int()
-            # # range_CI_pi = CI_pi[1] - CI_pi[0]
-            # range_CI_lambda_ = CI_lambda_[1] - CI_lambda_[0]
-        
-        return np.array([lambda_, pi])
+            return np.array([fit.params[1], fit.params[0]]) # lambda, pi
         
     @staticmethod
     def zinb_nloglike(params, data, alpha_prior):
-        
-        # Unpack the real-valued input params
-        x_lambda, x_pi = params
-        
-        # Apply transformations to get the actual parameters
-        lambd = np.exp(x_lambda)  # Lambda must be positive
-        pi = 1 / (1 + np.exp(-x_pi))  # Pi must be in the interval (0, 1)
-        
-        # Calculate the probability of success p using lambda and alpha
+        lambd = np.exp(params[0])
+        pi = 1 / (1 + np.exp(-params[1]))
         p = alpha_prior / (lambd + alpha_prior)
-        
-        # Create a boolean mask for zero observations
-        zero_mask = (data == 0)
-        
-        # Calculate the Negative Binomial PMF for all y
         nb_pmf = stats.nbinom.pmf(data, alpha_prior, p)
-        
-        # Compute log likelihood for zeros
-        log_likelihood_zeros = np.log(pi + (1 - pi) * nb_pmf)  # Log for the zeros
-        
-        # Compute log likelihood for non-zeros
-        log_likelihood_nonzeros = np.log((1 - pi) * nb_pmf)  # Log for the non-zeros
-        
-        # Apply the appropriate log likelihood based on whether y = 0 or y > 0
-        log_likelihood = np.sum(zero_mask * log_likelihood_zeros + (1 - zero_mask) * log_likelihood_nonzeros)
-        
+        log_likelihood = np.sum(np.where(data == 0, np.log(pi + (1 - pi) * nb_pmf), np.log((1 - pi) * nb_pmf)))
         return -log_likelihood
 
     @staticmethod
-    def calc_MAP(chain, bins=False):
-
-        if not bins:
-            bins = 100
-
+    def calc_MAP(chain, bins=100):
         counts, bins = np.histogram(chain, bins=bins)
-        max_idx = np.argmax(counts)
-        
-        return bins[max_idx]
-    
-    @staticmethod
-    def _calc_p_posterior(total_counts, scaleby,
-                          b=1,
-                          c=1):
-        '''
-        Empirical posterior distribution over p for Nbinom-distributed counts.
-        Calculate with a beta(b,c) prior over p
-        '''
-        
-        #If underdispersed relative to Poisson skip calc because it will break
-        if np.var(total_counts) <= np.mean(total_counts):
-            
-            return (np.sum(total_counts),1)
-            
-        k = np.mean(total_counts)**2/(np.var(total_counts)-np.mean(total_counts))
-        T = len(total_counts)
-        alpha_update = (k * T) + b
-        beta_update = np.sum(total_counts) + c
-        
-        # Empirical max value of p
-        # p_max = np.mean(total_counts)/np.var(total_counts)
-        
-        return (alpha_update/scaleby, beta_update/scaleby)
-
-    
-    @staticmethod
-    def _zip_nloglike(params, counts):
-        '''
-        Negative log-likelihood function for zero-inflated Poisson
-        '''
-        
-        lambda_ = params[0]
-        pi = params[1]
-        
-        if lambda_ <= 0:
-            return np.inf
-        if pi < 0 or pi > 1:
-            return np.inf
-    
-        Y=len(counts) - np.count_nonzero(counts)
-        n=len(counts)
-        
-        return -( Y*np.log(pi + (1 - pi)*np.exp(-lambda_)) +
-                  (n - Y) * np.log(1 - pi) - 
-                  (n - Y) * lambda_ + 
-                  n * np.mean(counts) * np.log(lambda_) -
-                  np.sum(np.log(np.array([np.math.factorial(int(c)) for c in counts], dtype=float))) )
-                  #np.log(np.product(np.array([np.math.factorial(int(c)) for c in counts], dtype='float128'))) )
+        return bins[np.argmax(counts)]
     
     @staticmethod
     def sample_lambda_i_conditional(a, b, counts, r_i):
-        
-        return stats.gamma.rvs(a = a+counts,
-                               scale = 1/(r_i+b))
+        return stats.gamma.rvs(a=a+counts, scale=1/(r_i+b))
     
     @staticmethod
     def sample_p_conditional(ri, npts):
-        
         return stats.beta.rvs(np.sum(ri)+1, npts - np.sum(ri) + 1)
     
     @staticmethod
-    def sample_ri_conditional(npts, pi, lambda_i, 
-                              zero_idx, nonzero_idx):
-        # If yi > 0, then point i belongs to the at-risk class,
-        # and hence by definition, ri = 1 with probability 1.
-        # If yi = 0, then we observe either a structural zero (ri = 0) 
-        # or an at-risk zero (ri = 1). 
-        
-        # Draw wi from a Bernoulli distribution with probability
+    def sample_ri_conditional(npts, pi, lambda_i, zero_idx, nonzero_idx):
         ri = np.zeros(npts)
-        
-        predicted_prob_zero = (1/(1+(np.var(lambda_i)/np.mean(lambda_i))))**(np.mean(lambda_i)**2/np.var(lambda_i))
-        
-        # zero_bern = ( (pi*np.exp(-np.sum(lambda_i)))/
-        #               ((pi*np.exp(-np.sum(lambda_i)))+(1-pi)) )
-        zero_bern = ( (pi*predicted_prob_zero)/
-                      ((pi*predicted_prob_zero)+(1-pi)) )
-    
-        # Note as np.exp(-np.sum(lambda_i)) reaches the floating
-        # point limit the overall term will go to 0
-        if len(zero_idx) > 0:
-            ri[zero_idx] = stats.bernoulli.rvs(zero_bern, size=len(zero_idx))
-        if len(nonzero_idx) > 0:
-            ri[nonzero_idx] = stats.bernoulli.rvs(1, size=len(nonzero_idx))
-    
+        pred_prob_zero = (1/(1+(np.var(lambda_i)/np.mean(lambda_i))))**(np.mean(lambda_i)**2/np.var(lambda_i))
+        zero_bern = (pi*pred_prob_zero) / ((pi*pred_prob_zero)+(1-pi))
+        if len(zero_idx) > 0: ri[zero_idx] = stats.bernoulli.rvs(zero_bern, size=len(zero_idx))
+        if len(nonzero_idx) > 0: ri[nonzero_idx] = 1
         return ri
     
     @staticmethod
-    def sample_a_conditional_gp(aparams,
-                                a_old):
-        
+    def sample_a_conditional_gp(aparams, a_old):
         def log_a_conditional_dist_gp(a, params):
-            ''' 
-            Conditional distribution of a (gamma shape parameter) 
-            in a gamma-poisson model
-            '''
-            
-            lambda_i, b, v, m, logp = params
-            
-            # Will cause -inf error
-            lambda_i = lambda_i[np.nonzero(lambda_i)]
-            
-            npts = len(lambda_i)
-            
-            return (a*(npts+v)*np.log(b) + 
-                    (a)*logp + 
-                    a*np.sum(np.log(lambda_i)) - 
-                    (m + npts)*loggamma(a))
-
-        if log_a_conditional_dist_gp(a_old, aparams) == -np.inf:
-            raise RuntimeError('Loglikelihood is too low!')
-            
-        chain = slice_sampler(x0=a_old, 
-                              loglike=log_a_conditional_dist_gp, 
-                              params=aparams,
-                              niter=50,
-                              sigma=a_old/10, 
-                              step_out=True)
-        
-        return chain
+            li, b, v, m, lp = params
+            li = li[li > 0]
+            return (a*(len(li)+v)*np.log(b) + a*lp + a*np.sum(np.log(li)) - (m + len(li))*loggamma(a))
+        return slice_sampler(x0=a_old, loglike=log_a_conditional_dist_gp, params=aparams, niter=50, sigma=a_old/10)
     
     @staticmethod
-    def sample_b_conditional(a,
-                             v, s,
-                             data, npts):
-        
-        return stats.gamma.rvs(a = a*(npts + v),
-                                scale = 1/(s + np.sum(data)))    
-    
+    def sample_b_conditional(a, v, s, data, npts):
+        return stats.gamma.rvs(a=a*(npts + v), scale=1/(s + np.sum(data)))    
     
     @staticmethod
     def get_hpd(chain, interval_size=0.95):
-        """
-        Returns highest probability density region for a given interval
-        """
-        # Get sorted list
         d = np.sort(np.copy(chain))
-    
-        # Number of total samples taken
         n = len(chain)
-        
-        # Get interval size that should be included in HPD
         interval = np.floor(interval_size * n).astype(int)
-        
-        # Get width (in units of param) of all intervals 
         int_width = d[interval:] - d[:n-interval]
-        
-        # Pick out minimal interval
         min_int = np.argmin(int_width)
-        
-        # Return interval
         return np.array([d[min_int], d[min_int+interval]])
-    
-def slice_sampler(x0, 
-                  loglike, params,
-                  niter, sigma, 
-                  step_out=True):
-    """
-    based on http://homepages.inf.ed.ac.uk/imurray2/teaching/09mlss/
-    """
 
-    # set up empty sample holder
+def slice_sampler(x0, loglike, params, niter, sigma, step_out=True):
     samples = np.zeros(niter)
-
-    # initialize
     xx = float(x0)
-
     last_llh = loglike(xx, params)
-
     for i in range(niter):
-                    
-        # =================================================================
-        #  Randomly sample y from (0,L(X))
-        # =================================================================
-        # aka multiply likelihood by uniform[0,1]
         llh0 = last_llh + np.log(np.random.rand())
-        
-        # =================================================================
-        #  Get straight line segment at y under the curve L(x)
-        # =================================================================
-        rr = np.random.rand(1)
-
-        # Initialize left and right of segment with total distance sigma
-        x_l = float(xx)
-        x_l = x_l - rr * sigma
-        x_r = float(xx)
-        x_r = x_r + (1 - rr) * sigma
-        
-        # Continue to take steps of sigma out until you get ends outside the curve
-            #"stepping out"
+        rr = np.random.rand()
+        x_l, x_r = xx - rr * sigma, xx + (1 - rr) * sigma
         if step_out:
-            llh_l = loglike(x_l, params)
-            while llh_l > llh0:
-                x_l = x_l - sigma
-                llh_l = loglike(x_l, params)
-            llh_r = loglike(x_r, params)
-            while llh_r > llh0:
-                x_r = x_r + sigma
-                llh_r = loglike(x_r, params)
-
-        # =================================================================
-        #  Randomly sample a new x from within the total segment 
-        # =================================================================
-            #"shrinkage"
-        x_cur = float(xx)
+            while loglike(x_l, params) > llh0: x_l -= sigma
+            while loglike(x_r, params) > llh0: x_r += sigma
         while True:
             xd = np.random.rand() * (x_r - x_l) + x_l
-            x_cur = float(xd)
-            last_llh = loglike(x_cur, params)
-            
-            #If the loglikelihood of new x is higher than y, good to go
+            last_llh = loglike(xd, params)
             if last_llh > llh0:
-                xx = float(xd)
-                break
-            # Otherwise make new x the new left/right end of segment
-            elif xd > xx:
-                x_r = xd
-            elif xd < xx:
-                x_l = xd
-            else:
-                raise RuntimeError('Slice sampler shrank too far.')
-
-        samples[i] = float(xx)
-
+                xx = xd; break
+            elif xd > xx: x_r = xd
+            else: x_l = xd
+        samples[i] = xx
     return samples
 
 class ZeroInflatedPoisson(GenericLikelihoodModel):
-    
     def __init__(self, endog, exog=None, **kwds):
-        if exog is None:
-            exog = np.zeros_like(endog)
-            
+        if exog is None: exog = np.zeros_like(endog)
         super(ZeroInflatedPoisson, self).__init__(endog, exog, **kwds)
     
     def nloglikeobs(self, params):
-        pi = params[0]
-        lambda_ = params[1]
-
-        return -np.log(self._zip_pmf(self.endog, pi=pi, lambda_=lambda_))
+        return -np.log(self._zip_pmf(self.endog, pi=params[0], lambda_=params[1]))
     
     def fit(self, start_params=None, maxiter=10000, maxfun=5000, **kwds):
         if start_params is None:
-            lambda_start = self.endog.mean()
-            excess_zeros = (self.endog == 0).mean() - stats.poisson.pmf(0, lambda_start)
-            pi_start = excess_zeros if excess_zeros>0 else 0
-            start_params = np.array([pi_start, lambda_start])
-            
-        return super(ZeroInflatedPoisson, self).fit(start_params=start_params,
-                                                    maxiter=maxiter, maxfun=maxfun, **kwds)
+            l_start = self.endog.mean()
+            pi_start = max(0, (self.endog == 0).mean() - stats.poisson.pmf(0, l_start))
+            start_params = np.array([pi_start, l_start])
+        return super(ZeroInflatedPoisson, self).fit(start_params=start_params, maxiter=maxiter, maxfun=maxfun, **kwds)
     
     @staticmethod
     def _zip_pmf(x, pi, lambda_):
-        '''zero-inflated poisson function, pi is prob. of 0, lambda_ is the fit parameter'''
-        if pi < 0 or pi > 1 or lambda_ <= 0:
-            return np.zeros_like(x)
-        else:
-            return (x == 0) * pi + (1 - pi) * stats.poisson.pmf(x, lambda_)
+        if pi < 0 or pi > 1 or lambda_ <= 0: return np.zeros_like(x)
+        return (x == 0) * pi + (1 - pi) * stats.poisson.pmf(x, lambda_)
 
 class PhyloLevel:
-    '''
-    Holds a set phylogenetic level in reference to a classifier.
-    '''
-    
     def __init__(self, levelin, allclades, allclade_names):
-        
-        # Import information about the tree
-        # Note: ideally this will be replaced by an import of a classifier class
-        self.__allclades = allclades
-        self.__allclade_names = allclade_names
-        
-        # Import levels from file or string
+        self.__allclades, self.__allclade_names = allclades, allclade_names
         if os.path.isfile(levelin):
-            print('Reading in levels file...')
             self.clades, self.clade_names, self.names = self._parse_file(levelin)
-        
-        else: 
-            print('Searching for the following levels in classifier:')
-            print(levelin)
+        else:
             self.clades, self.clade_names, self.names = self._parse_str(levelin)
             
-    def _parse_file(self, levelin_file, uncl='-1'):
-        '''
-        Parse a 2 column delimited levels file 
-        ( e.g genome_name1, clade_ID1
-              genome_name2, clade_ID2 )
-        '''
-        
-        with open(levelin_file,'r') as file:
-            firstline = file.readline()
-       
-        if len(firstline.strip().split('\t'))==2:
-            dlim='\t'
-        elif len(firstline.strip().split(','))==2:
-            dlim=','
-
-
+    def _parse_file(self, levelin_file):
+        with open(levelin_file, 'r') as f:
+            line = f.readline()
+        dlim = '\t' if '\t' in line else ','
         clade_ids = np.loadtxt(levelin_file, delimiter=dlim, dtype=str)
-        
-        clades, names = self._reshape(clade_ids[:,0],
-                                      clade_ids[:,1],
-                                      '-1')
-        
-        # Check that level is valid within classifier
+        clades, names = self._reshape(clade_ids[:,0], clade_ids[:,1], '-1')
         clade_names = self._check_file(clades, names)
-        
-        # Check that levels are not direct ancestors or descendants
-        # of each other.
         self._ancdesc(clades, clade_names)
-        
         return clades, clade_names, names
 
     def _parse_str(self, levelin_str):
-        '''
-        Parse a comma-delimited list of clade names (e.g. C.1,C.2,C.3)
-        '''
         clade_names = levelin_str.strip().split(',')
-        
-        # Check that level is valid within classifier
         clades = self._check_str(clade_names)
-        names = clade_names
-        
-        # Check that levels are not direct ancestors or descendants
-        # of each other.
         self._ancdesc(clades, clade_names)
-        
-        return clades, clade_names, names
+        return clades, clade_names, clade_names
     
     def _check_file(self, clades, names):
-        '''
-        Check that groupings specified by a file are valid clades in classifer.
-        '''
-        
-        clade_names=[]
-        allclades_ls = list(self.__allclades.values())
-        allclade_names = np.array(list(self.__allclades.keys()))
-        
-        # Plus return the missing data (clade_names)
+        clade_names = []
+        all_c_vals = list(self.__allclades.values())
+        all_c_keys = np.array(list(self.__allclades.keys()))
         for i, clade in enumerate(clades):
-        
-            # Check if grouping of genomes is actually a clade in classifier
-            match_bool = [ set(clade) == set(genomes) for genomes in allclades_ls ]
-            
-            if np.sum(match_bool)==0:
-                raise Exception(f"Error: Could not find a valid clade corresponding to {names[i]} in classifier.")
-            
-            # Ugly
-            clade_names.append(str(allclade_names[match_bool][0]))
-            
+            match = [set(clade) == set(genomes) for genomes in all_c_vals]
+            if not any(match): raise Exception(f"Clade {names[i]} not in classifier.")
+            clade_names.append(str(all_c_keys[match][0]))
         return clade_names
     
     def _check_str(self, clade_names):
-        '''
-        Check if clade names specified are valid clades in classifier.
-        '''
         clades = []
-        
         for name in clade_names:
-
-            if name not in self.__allclade_names:
-                raise Exception(f"Error: {name} is not a valid clade in the classifier!")
-
+            if name not in self.__allclade_names: raise Exception(f"{name} invalid.")
             clades.append(self.__allclades[name])
-            
         return clades
     
     @staticmethod
     def _ancdesc(clades, clade_names):
-        '''
-        Check that no two clades in a level are direct ancestors or descendants 
-        of each other.
-        '''
-
         for i, clade in enumerate(clades):
-            
-            # Get other clades to cp against
-            cp = (clades[:i] + clades[i+1 :])
-            
-            # Are any genomes duplicated in 2 clades
-            dup_bool = [len(set(clade).intersection(set(genomes)))>0 for genomes in cp]
-
-            if np.sum(dup_bool) > 0:
-                raise Exception(f"Error: {clade_names[i]} is either an ancestor or descendant of {clade_names[dup_bool.index(True)]}.",
-                                "Note that within a level the same genome cannot be included in two clades.")
+            cp = clades[:i] + clades[i+1:]
+            if any([len(set(clade).intersection(set(g))) > 0 for g in cp]):
+                raise Exception(f"{clade_names[i]} overlaps with another clade.")
 
     @staticmethod
-    def _reshape(names_long, clade_ids_long, uncl_marker):
-        '''
-        Reshape a two column 'long' levels array into list of arrays
-        '''
-        
-        clades = []; names = []
-        
-        for c in np.unique(clade_ids_long):
-            names.append(str(c))
-            clades.append(names_long[np.isin(clade_ids_long,c)])
-        
-        # Remove things designated as unclassifed
-        if uncl_marker in names:
-            # Get index of unclassified names
-            idx = names.index(uncl_marker)
-            # And remove
-            del names[idx]; del clades[idx]
-        
-        else:
-            print('Nothing was found as unclassified in clade IDs. Ignore if intentional!')
-                
+    def _reshape(names_long, ids_long, uncl):
+        clades, names = [], []
+        for c in np.unique(ids_long):
+            if c != uncl:
+                names.append(str(c))
+                clades.append(names_long[ids_long == c])
         return clades, names
+
+# =====================================================================
+#  Entry Point
+# =====================================================================
+if __name__ == "__main__":
+    # Example usage:
+    # classifier = Classify(...)
+    # classifier.main()
+    pass

--- a/phlame/cmt2tree.py
+++ b/phlame/cmt2tree.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Feb 18 14:50:42 2022
+
+@author: evanqu
+"""
+import argparse
+import os
+import subprocess
+import pickle
+import gzip
+import time
+import datetime
+import glob
+import numpy as np
+from Bio import AlignIO
+from Bio import SeqIO
+
+#%% Testing
+
+# NOTE! THIS VERSION IS EXCLUSIVELY FOR TESTING. PULL FROM THE VERSION IN /phlame/snakemake_make_classifier/scripts/
+
+os.chdir("/Users/evanqu/Dropbox (MIT)/Lieberman Lab/Personal lab notebooks/Evan/1-Projects/phlame_project/results/2022_03_makeclassifiers/Cacnes_acera_isolates_NEW2023")
+input_cmt_file="Cacnes_repCMT.pickle.gz"
+output_phylip="Cacnes_acera"
+output_name_ids="Cacnes_acera_phylip2names.txt"
+refGenome_file="/Users/evanqu/Dropbox (MIT)/Lieberman Lab/Personal lab notebooks/Evan/reference_genomes/Pacnes_C1.fasta"
+
+min_cov_to_include=8
+min_maf_for_call=0.85
+min_strand_cov_for_call=2
+min_qual_for_call=-30
+min_presence_core=0.95
+min_median_cov_samples=3
+remov_recomb=True
+consider_indels=False
+
+# existing tree
+# os.chdir("/Users/evanqu/Dropbox (MIT)/Lieberman Lab/Personal lab notebooks/Evan/1-Projects/phlame_project/results/2022_03_makeclassifiers/Sepi_acera_isolates_NEW2023")
+# intree="tree/Sepi_acera_pars_norecomb.tre"
+# phylip2names_file="tree/Sepi_acera_phylip2names.txt"
+# outtree="tree/Sepi_acera_pars_norecomb_isonames.tre"
+
+
+# cmt2phylip(input_cmt_file, output_phylip, output_name_ids, refGenome_file,
+#             consider_indels=False, remov_recomb=False)
+
+# rename_phylip(phylip2names_file, intree, outtree, outclustertree=False, rep_CMT_file=False)
+
+np.savetxt('goodpos_60282.txt',pos[goodpos], fmt='%i')
+
+#%%
+
+def cmt2phylip(input_cmt_file, output_phylip, output_name_ids, refGenome_file,
+               min_cov_to_include=8, min_maf_for_call=0.85,
+               min_strand_cov_for_call=2, min_qual_for_call=-30,
+               min_presence_core=0.987,min_median_cov_samples=3,
+               consider_indels=False,remov_recomb=False):
+    '''Finds fixed mutations within a set of samples and outputs phylip format file
+
+    Args:
+        input_cmt_file (str): Path to input candidate mutation table.
+        output_phylip (str): Path to output phylip file.
+        output_name_ids (str): Path to output file to rename phylip names to original.
+        min_cov_to_include (float, optional): Minimum avg. coverage across positions to include a sample. Defaults to 8.
+        min_maf_for_call (float, optional): Minimum major allele frequency to call a major allele for position. Defaults to 0.85.
+        min_strand_cov_for_call (int, optional): Minimum coverage per strand to call a major allele for position. Defaults to 2.
+        min_qual_for_call (int, optional): Minimum mapping quality to call a major allele for position. Defaults to -30.
+        min_presence_core (float, optional): Minimum presence across samples to include a position. Defaults to 0.9.
+        min_median_cov_samples (int, optional): Minimum median coverage across samples to include a position. Defaults to 3.
+        consider_indels (bool, optional): Consider number of indels when filtering a position. Defaults to False.
+        
+    Returns:
+        None.
+
+    '''
+    
+    filterby_sample = {\
+                       'min_cov_to_include':min_cov_to_include
+                       }
+    
+    filterby_site_per_sample = {\
+                              'min_maf_for_call':min_maf_for_call,
+                              'min_strand_cov_for_call':min_strand_cov_for_call,
+                              'min_qual_for_call': min_qual_for_call,
+                              }
+    
+    filterby_site_across_samples = {\
+                                  'min_presence_core':min_presence_core,
+                                  'min_median_cov_samples':min_median_cov_samples,
+                                  }
+        
+    filter_parameter_recombination = {\
+                                'distance_for_nonsnp' : 300, #region in bp on either side of goodpos that is considered for recombination
+                                'corr_threshold_recombination' : 0.75 #minimum threshold for correlation
+                                }
+    NTs = np.array(['A','T','C','G'],dtype=object) # NTs='ATCG'
+
+        
+    print("Reading in candidate mutation table....")
+    
+    sample_names, pos, counts, quals, indel_counter = read_counts_table(input_cmt_file)
+    
+    ### Modify some structures ###
+    sample_names_all=np.asarray(sample_names,dtype=object)
+    #reduce indel_counter to pxs matrix giving count for indels overall
+    # indels_all=np.sum(indel_counter,axis=0)
+    coverage_all=counts.sum(axis=0) #pxs
+    
+    print("Filtering samples...")
+    
+    #samples that pass sample-wise filters
+    good_sample_bool = coverage_all.mean(axis=0) > float(filterby_sample['min_cov_to_include'])
+    
+    good_sample_names = sample_names_all[good_sample_bool]
+    good_counts = counts[:,:,good_sample_bool]
+    good_quals = quals[:,good_sample_bool]
+    # good_indels = indels_all[:,good_sample_bool]
+    
+    num_samples=len(good_sample_names)
+    coverage=good_counts.sum(axis=0)
+    coverage_f_strand=good_counts[0:4,:,:].sum(axis=0) #should be pxs
+    coverage_r_strand=good_counts[4:8,:,:].sum(axis=0)
+
+    print(f"{num_samples}/{len(sample_names)} samples passed coverage filter.")
+    print("The following samples did NOT pass coverage filter; NOT included:")
+    print( sample_names_all[coverage_all.mean(axis=0) < float(filterby_sample['min_cov_to_include'])] )
+    
+    if num_samples < 3:
+        raise Exception("Too few samples fullfill filter criteria!")
+        
+    print("Filtering positions...")
+    #Get major allele at each position
+    [maNT, maf, minorNT, minorAF] = get_major_allele_nt(good_counts)
+    
+    # Define mutations that pass filters in each and across samples.
+    calls = np.copy(maNT)
+    #remember quals are negative!
+    calls[ good_quals > float(filterby_site_per_sample['min_qual_for_call']) ] = -1
+    calls[ maf < float(filterby_site_per_sample['min_maf_for_call']) ] = -1
+    calls[ coverage_f_strand < float(filterby_site_per_sample['min_strand_cov_for_call']) ] = -1
+    calls[ coverage_r_strand < float(filterby_site_per_sample['min_strand_cov_for_call']) ] = -1
+    
+    if consider_indels:
+        indels_all=np.sum(indel_counter,axis=0)
+        good_indels = indels_all[:,good_sample_bool]
+        calls[good_indels > (0.5*coverage)] = -1 #50%+ of reads @ site cannot support indel
+        
+    max_fracNs_bool = ( ((calls>-1).sum(axis=1)) <= \
+                        (num_samples*float(filterby_site_across_samples['min_presence_core'])) )
+    min_med_cov_bool = ( np.median(coverage, axis=1) < \
+                         float(filterby_site_across_samples['min_median_cov_samples']) )
+    
+    site_filter_bool=np.any((max_fracNs_bool,min_med_cov_bool),axis=0)
+    calls[site_filter_bool,:] = -1 # sites that fail qc ->-1, for all samples      
+    
+    print('Done filter.')
+    
+    print("Finding within-sample SNPs...")
+    mut_qual,mut_qual_isolates = ana_mutation_quality(calls,good_quals)
+    
+    # nan in mutQual gives a warning, which is fine (nan=False=excluded)
+    fixedmutation = (calls>-1)&(np.tile(mut_qual,(1,num_samples)) <= 1)
+    hasmutation = np.any((fixedmutation == True,),axis=0)
+    # NOTE: filteredpos is INDEX of filtered positions for p!
+    filteredpos = np.where(np.sum(hasmutation, axis=1)> 0)[0] 
+    
+    # remove pos that are not variable between samples 
+    # (fixed different to outgroup or N)
+    bool_allN_outgroup = (calls>-1)
+    # For outgroup functionality: NOT added yet!
+    # bool_allN_outgroup[:,outgroup_idx] = False 
+    
+    #indices of nonvariable positions
+    non_variable_idx = []
+    for i,fp in enumerate(filteredpos):
+        # identify sites non-variable between samples
+        if len(np.unique(calls[fp,:][bool_allN_outgroup[fp,:]])) == 1:
+            non_variable_idx.append(i)
+    
+    # NOTE: goodpos is INDEX of good positions for p!
+    goodpos = np.delete(filteredpos,non_variable_idx)
+    
+    print(str(len(goodpos)) + ' goodpos found.')
+    
+    if len(goodpos) < 3:
+        raise Exception("Too few positions after filter!")
+        
+    #  Check for recombination in p and remove positions from goodpos
+    if remov_recomb:
+        print("Filtering recombinant positions...")
+        # When no outgroup defined: refnt ~= ancnt:
+        [chrStarts, genomeLength, scafNames] = genomestats(refGenome_file);
+
+        refnt = extract_outgroup_mutation_positions(refGenome_file, p2chrpos(pos,chrStarts));
+        ancnt = refnt
+        ancnti_m = np.full(ancnt.shape, 9)
+        for idx,allele in enumerate(ancnt):
+            if allele in NTs:
+                ancnti_m[idx,] = np.where(NTs==allele)[0][0] # strip down to index number
+            else:
+                ancnti_m[idx,] = -1
+
+        recombpos = findrecombinantSNPs(pos, goodpos, good_counts, ancnti_m, num_samples, 
+                                        filter_parameter_recombination['distance_for_nonsnp'],
+                                        filter_parameter_recombination['corr_threshold_recombination'])
+
+        #These are the positions in p that are likely recombinant that we will remove from goodpos
+        print(str(sum(np.isin(goodpos, recombpos))) + ' of a total ' + str(goodpos.shape[0]) + ' ('  + str(sum(np.isin(goodpos, recombpos))/goodpos.shape[0]*100) + '%) positions in goodpos were found to be recombinant.')
+        goodpos=goodpos[~np.isin(goodpos, recombpos)]
+    
+    print("Writing phylip file...")
+    # grab calls only at goodpos
+    # numpy broadcasting of row_array requires np.ix_()
+    calls_for_treei=calls[np.ix_(goodpos)]
+    # Convert -10123 to NATCG translation
+    calls_for_tree = idx2nts(calls_for_treei) 
+    
+    sample_names_4phylip = np.char.add(np.arange(0,len(good_sample_names)).astype(str), \
+                                      good_sample_names.astype(str)).astype(object)
+    
+    #.dnapars.fa > for dnapars...deleted later
+    write_calls_to_fasta(calls_for_tree,sample_names_4phylip,output_phylip+".dnapars.fa") 
+    # turn fa to phylip and delete fasta with short tip labels    
+    aln = AlignIO.read(output_phylip+".dnapars.fa", 'fasta')
+    AlignIO.write(aln, output_phylip+".phylip", "phylip")
+    subprocess.run(["rm -f " + output_phylip+".dnapars.fa"],shell=True)
+
+    # Write object to convert phylip names back at the end
+    with open(output_name_ids,'w') as f:
+        for line in range(len(good_sample_names)):
+            f.write(f"{sample_names_4phylip[line][:10]}\t{good_sample_names[line]}\n")
+
+def read_counts_table(path_to_cmt_file):
+    
+    if path_to_cmt_file.endswith('.pickle.gz'):
+        with gzip.open(path_to_cmt_file,'rb') as f:
+            CMT = pickle.load(f)
+            
+            if type(CMT)==dict:
+                counts = CMT['counts']; sample_names = CMT['sample_names']
+                pos = CMT['p']; quals=CMT['quals']; indel_counter=CMT['indel_counter']
+            else:
+                counts = CMT[2]; sample_names=CMT[0]; pos = CMT[1]; quals = CMT[3]; indel_counter=CMT[4]
+            
+    elif path_to_cmt_file.endswith('.pickle'):
+        with open(path_to_cmt_file,'rb') as f:
+            CMT = pickle.load(f)
+            
+            if type(CMT)==dict:
+                counts = CMT['counts']; sample_names = CMT['sample_names']
+                pos = CMT['p']; quals=CMT['quals']; indel_counter=CMT['indel_counter']
+            else:
+                counts = CMT[2]; sample_names=CMT[0]; pos = CMT[1]; quals = CMT[3]; indel_counter=CMT[4]
+    
+    else:
+        raise IOError("Error: candidate mutation table does not end in .pickle or .pickle.gz!")
+        
+    if np.size(counts,axis=0) != 8:
+        print('Transposing counts table...')
+        counts = counts.transpose(1,2,0)
+        
+    return [sample_names, pos, counts, quals, indel_counter]
+
+def genomestats(REFGENOMEFILE):
+    # parse ref genome to extract relevant stats
+    refgenome = SeqIO.parse(REFGENOMEFILE,'fasta')
+    Genomelength = 0
+    ChrStarts = []
+    ScafNames = []
+    for record in refgenome:
+        ChrStarts.append(Genomelength) # chr1 starts at 0 in analysis.m
+        Genomelength = Genomelength + len(record)
+        ScafNames.append(record.id)
+    # turn to np.arrys!
+    ChrStarts = np.asarray(ChrStarts,dtype=int)
+    Genomelength = np.asarray(Genomelength,dtype=int)
+    ScafNames = np.asarray(ScafNames,dtype=object)
+    return [ChrStarts,Genomelength,ScafNames]
+
+def get_major_allele_nt(counts):
+    
+    c=counts[0:4,:,:]+counts[4:8,:,:]; # flatten frw and rev ATCG counts    
+
+    sorted_arr = np.sort(c,axis=0) #sort by ATCG counts
+    sortedpositions = np.argsort(c,axis=0) # return matrix indices of sort
+    
+    # get allele counts for major allele (4th row)
+    # weird "3:4:" indexing required to maintain 3d structure
+    maxcount = sorted_arr[3:4:,:,:] 
+    # get allele counts for first minor allele (3rd row)
+    # tri/quadro-allelic ignored!!
+    minorcount = sorted_arr[2:3:,:,:] 
+    
+    with np.errstate(divide='ignore', invalid='ignore'):
+        maf = maxcount / sorted_arr.sum(axis=0,keepdims=True)
+        minorAF = minorcount / sorted_arr.sum(axis=0,keepdims=True)
+    maf = np.squeeze(maf,axis=0) # turn 2D; axis=1 to keep 2d structure when only one position!
+    maf[np.isnan(maf)]=0 # set to 0 to indicate no data
+    minorAF = np.squeeze(minorAF,axis=0) 
+    minorAF[np.isnan(minorAF)]=0 # set to 0 to indicate no data/no minor AF
+    
+    # index position in sortedpositions represents allele position ATCG;
+    # A=0,T=1,C=2,G=3
+    # axis=1 to keep 2d structure when only one position!
+    majorNT = np.squeeze(sortedpositions[3:4:,:,:],axis=0) 
+    minorNT = np.squeeze(sortedpositions[2:3:,:,:],axis=0)
+
+    # Note: If counts for all bases are zero, then sort won't change the order
+    # (since there is nothing to sort), thus majorNT/minorNT will be put to -1 (NA)
+    # using maf (REMEMBER: minorAF==0 is a value!)
+    majorNT[maf==0]=-1
+    minorNT[maf==0]=-1
+    
+    return majorNT, maf, minorNT, minorAF
+
+def ana_mutation_quality(calls,quals):
+    # This function calls mutations within the data itself, instead of wrt reference 
+    # It takes as input the called nucleotides (calls) and the quality score (qual)
+    # and outputs only the mutation call quality (mut_qual) calculated as 
+    # max_i(min_j(Qual_i, Qual_j)) for i,j over all samples with different calls
+    # It also outputs the samples giving this maxmin quality (mut_qual_isolates)
+    
+    # If there is no within data mutation in a given position (all nucleotides
+    # are equal, but different from the reference), mut_qual returns 0 at that
+    # position.
+    
+    [n_muts, n_strain] = calls.shape ;
+    mut_qual = np.zeros((n_muts,1)) ; 
+    mut_qual_isolates = np.zeros((n_muts,2)); 
+    
+    # generate template index array to sort out strains gave rise to reported FQ values
+    s_template=np.zeros( (len(calls[0,:]),len(calls[0,:])) ,dtype=object)
+    for i in range(s_template.shape[0]):
+        for j in range(s_template.shape[1]):
+            s_template[i,j] = str(i)+"_"+str(j)
+
+    for k in range(n_muts):
+        if len(np.unique(np.append(calls[k,:], 4))) <= 2: # if there is only one type of non-N (4) call, skip this location
+            mut_qual[k] = np.nan ;
+            mut_qual_isolates[k,:] = 0; 
+        else:
+            c = calls[k,:] ; c1 = np.tile(c,(c.shape[0],1)); c2 = c1.transpose() # extract all alleles for pos k and build 2d matrix and a transposed version to make pairwise comparison
+            q = quals[k,:] ; q1 = np.tile(q,(q.shape[0],1)); q2 = q1.transpose() # -"-
+            g = np.all((c1 != c2 , c1 != 4 , c2 != 4) ,axis=0 )  # no data ==4; boolean matrix identifying find pairs of samples where calls disagree (and are not N) at this position
+            #positive_pos = find(g); # numpy has no find; only numpy where, which does not flatten 2d array that way
+            # get mut_qual + logical index for where this occurred
+            mut_qual[k] = np.max(np.minimum(q1[g],q2[g])) # np.max(np.minimum(q1[g],q2[g])) gives lower qual for each disagreeing pair of calls, we then find the best of these; NOTE: np.max > max value in array; np.maximum max element when comparing two arryas
+            MutQualIndex = np.argmax(np.minimum(q1[g],q2[g])) # return index of first encountered maximum!
+            # get strain ID of reorted pair (sample number)
+            s = s_template
+            strainPairIdx = s[g][MutQualIndex]
+            mut_qual_isolates[k,:] = [strainPairIdx.split("_")[0], strainPairIdx.split("_")[1]]
+            
+    return [mut_qual,mut_qual_isolates]
+
+
+def idx2nts(calls, missingdata="?"):
+    # translate index array to array containing nucleotides
+    # add 5th element --> no data! == index -1
+    nucl = np.array([missingdata,'A','T','C','G'],dtype=object) 
+    palette = [-1,0,1,2,3] # values present in index-array
+    index = np.digitize(calls.ravel(), palette, right=True)
+    
+    return nucl[index].reshape(calls.shape)
+
+def write_calls_to_fasta(calls,sample_names,output_file):
+    
+    fa_file = open(output_file, "w")
+    
+    for i,name in enumerate(sample_names):
+        nucl_string = "".join(list(calls[:,i]))
+        fa_file.write(">" + name + "\n" + nucl_string + "\n")
+    
+    fa_file.close()
+
+def extract_outgroup_mutation_positions(REFGENOMEFILE,position):
+    # extracts the ref nucleotide for every position. positions needs to be sorted by chr
+    # CMTpy=True: if old matlab build_candidate_mutation.mat used, put flag False. p 1-based correction
+    refgenome = SeqIO.parse(REFGENOMEFILE,'fasta')
+    refnt = np.zeros(position.shape[0],dtype=object)
+    pos_counter = 0
+    chr_counter = 1
+    for record in refgenome:
+        poschr = position[ position[:,0]==chr_counter , 1]
+        for sglpos in poschr:
+            refnt[pos_counter] = str(record.seq)[sglpos] 
+
+            pos_counter += 1
+        chr_counter += 1
+    return refnt
+
+def p2chrpos(p, ChrStarts):
+    '''# return 2col array with chr and pos on chr
+    #p...continous, ignores chr
+    #pos: like p, 0-based'''
+
+    # get chr and pos-on-chr
+    chr = np.ones(len(p),dtype=int)
+    if len(ChrStarts) > 1:
+        for i in ChrStarts[1:]:
+            chr = chr + (p > i) # when (p > i) evaluates 'true' lead to plus 1 in summation. > bcs ChrStarts start with 0...genomestats()
+        positions = p - ChrStarts[chr-1] # [chr-1] -1 due to 0based index
+        pos = np.column_stack((chr,positions))
+    else:
+        pos = np.column_stack((chr,p))
+    return pos
+
+
+def findrecombinantSNPs(pos, goodpos, good_counts, ancnti_m, num_samples, 
+                        distance_for_nonsnp, 
+                        corr_threshold_recombination):
+
+    ancnti_rep=np.tile(ancnti_m, (num_samples, 1)).T     #make new array that is ancti_m long x Nsample across
+    [cmajorNT, cmajorAF, cminorNT, cminorAF] = get_major_allele_nt(good_counts)     #generates data structures of allele frequencies
+    #return majorNT, maf, minorNT, minorAF
+    cminorAF[np.isnan(cminorAF)]=0     #set nan values to 0
+
+    #create mutantAF
+    mutantAF=np.zeros((cmajorNT.shape))
+    mutantAF[np.where(cmajorNT!=ancnti_rep)] = cmajorAF[np.where(cmajorNT!=ancnti_rep)]
+    mutantAF[np.where(cminorNT!=ancnti_rep)] = mutantAF[np.where(cminorNT!=ancnti_rep)]+cminorAF[np.where(cminorNT!=ancnti_rep)]
+
+    #look for recombination regions
+    nonsnp = []
+    for i in range(len(goodpos)):
+        if (i % 5000) == 0:
+            print(".")
+        gp = pos[goodpos[i]]
+        #find nearby snps
+        if gp > distance_for_nonsnp:
+            region = np.array(np.where((pos > gp - distance_for_nonsnp) & (pos < gp + distance_for_nonsnp)) ).flatten()
+            if len(region)>1: 
+                r = mutantAF[region,:]
+                corrmatrix = np.corrcoef(r) 
+                [a,b]=np.where(corrmatrix > corr_threshold_recombination)
+                nonsnp.extend(list(region[a[np.where(a!=b)]]))
+    
+    nonsnp=np.unique(nonsnp)
+    
+    return nonsnp
+
+def generate_dnapars_tree(path_to_phylip_file,path_to_output_tree,
+                          path_to_renaming_file=False):
+    
+    # Write alignment file (as fasta)
+    # calc NJ or Parsimonous tree or None
+    # writeDnaparsAlignment==True for writing dnapars input for usage on cluster
+    ts = time.time()
+    timestamp = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d_%H-%M-%S')
+    
+    if not path_to_phylip_file.endswith('.phylip'):
+        path_to_phylip_file += '.phylip'
+        
+    # Find dnapars executable; searches up to 5 directories back
+    dnapars_path = glob.glob('dnapars')
+    path_extension = "../"
+    backstop = 0
+    while len(dnapars_path) == 0 and backstop <= 5:
+        dnapars_path = glob.glob(path_extension+'dnapars')
+        path_extension = path_extension + "../"
+        backstop = backstop + 1
+    if len(dnapars_path) == 0:
+        raise ValueError('Error: dnapars executable could not be located.')
+    elif dnapars_path[0]=='dnapars':
+        dnapars_path[0] = './dnapars'
+    
+    # Write parameters file
+    with open(f"{path_to_output_tree}_{timestamp}.options.txt",'w') as file:
+        file.write(path_to_phylip_file+"\n")
+        file.write("f"+"\n")
+        file.write(f"{path_to_output_tree}_{timestamp}.dnapars"+"\n")
+        file.write("5"+"\n")
+        file.write("V"+"\n")
+        file.write("1"+"\n")
+        file.write("y"+"\n")
+        file.write("f"+"\n")
+        file.write(f"{path_to_output_tree}_{timestamp}.tre"+"\n"+"\n") #Path to tree
+
+    # Run dnapars
+    print("Building parsimony tree...")
+    print( f"{dnapars_path[0]} < {path_to_output_tree}_{timestamp}_options.txt > {path_to_output_tree}_{timestamp}_dnapars.log")
+    subprocess.run([ "touch outtree"  ],shell=True)
+    subprocess.run([ f"{dnapars_path[0]} < {path_to_output_tree}_{timestamp}.options.txt > {path_to_output_tree}_{timestamp}.dnapars.log"  ],shell=True)
+    print("Done!")
+    
+    # Re-write tree with new long tip labels  
+    if path_to_renaming_file:
+        print("Renaming tree with original labels...")
+        path_to_output_renamed_tree=f"{path_to_output_tree}_isonames.tre"
+        rename_phylip(path_to_renaming_file,f"{path_to_output_tree}.tre",path_to_output_renamed_tree)
+
+    return timestamp
+
+def rename_phylip(phylip2names_file, intree, outtree, 
+                  outclustertree=False, rep_CMT_file=False):
+    '''Given a renaming file, rename 10chr phylip names into long format
+
+    Args:
+        phylip2names_file (TYPE): DESCRIPTION.
+        intree (TYPE): DESCRIPTION.
+        outtree (TYPE): DESCRIPTION.
+
+    Returns:
+        None.
+
+    '''
+    # Get phylip2names as dict
+    phylip2names=dict()
+    with open(phylip2names_file) as f:
+        for line in f:
+            key, value = line.strip().split('\t')
+            phylip2names[key] = value
+            
+    # Replace phylip tree names
+    with open(intree) as f:
+        nwk=f.read()
+    #Replace with representative isolate name
+    for i in phylip2names.keys():
+        nwk=nwk.replace(i,phylip2names[i])
+    with open(outtree,'w') as f:
+        f.write(nwk)
+    
+    if outclustertree: # Optionally output tree named by cluster
+    
+        # Get which tree isolate belongs to which cluster
+        with gzip.open(rep_CMT_file,'rb') as f:
+            CMT=pickle.load(f); sample_names=CMT[0]; cluster_IDs=CMT[4]
+        tree2cluster=dict()
+        for sam,clu in zip(sample_names,cluster_IDs):
+            tree2cluster[sam]=clu
+            
+        #Replace with cluster name
+        for i in tree2cluster.keys():
+            nwk=nwk.replace(i,'Cluster '+tree2cluster[i])
+        with open(outclustertree,'w') as f:
+            f.write(nwk)
+            
+            
+#%%
+# import matplotlib.pyplot as plt
+
+# num_samples=len(sample_names)
+
+# # When no outgroup defined: refnt ~= ancnt:
+# [chrStarts, genomeLength, scafNames] = genomestats(refGenome_file);
+
+# refnt = extract_outgroup_mutation_positions(refGenome_file, p2chrpos(pos,chrStarts));
+# ancnt = refnt
+# ancnti_m = np.full(ancnt.shape, 9)
+# for idx,allele in enumerate(ancnt):
+#     if allele in NTs:
+#         ancnti_m[idx,] = np.where(NTs==allele)[0][0] # strip down to index number
+#     else:
+#         ancnti_m[idx,] = -1
+        
+
+# ancnti_rep=np.tile(ancnti_m, (num_samples, 1)).T     #make new array that is ancti_m long x Nsample across
+# [cmajorNT, cmajorAF, cminorNT, cminorAF] = get_major_allele_nt(counts)     #generates data structures of allele frequencies
+# #return majorNT, maf, minorNT, minorAF
+# cminorAF[np.isnan(cminorAF)]=0     #set nan values to 0
+
+# #create mutantAF
+# mutantAF=np.zeros((cmajorNT.shape))
+# mutantAF[np.where(cmajorNT!=ancnti_rep)] = cmajorAF[np.where(cmajorNT!=ancnti_rep)]
+# mutantAF[np.where(cminorNT!=ancnti_rep)] = mutantAF[np.where(cminorNT!=ancnti_rep)]+cminorAF[np.where(cminorNT!=ancnti_rep)]
+
+# distance_for_nonsnp=500
+# corr_threshold_recombination=0.75
+# goodpos=np.arange(0,len(pos))
+
+# #look for recombination regions
+# nonsnp = []
+# for i in range(len(goodpos)):
+#     gp = pos[goodpos[i]]
+#     #find nearby snps
+#     if gp > distance_for_nonsnp:
+#         region = np.array(np.where((pos > gp - distance_for_nonsnp) & (pos < gp + distance_for_nonsnp)) ).flatten()
+#         if len(region)>1: 
+#             r = mutantAF[region,:]
+#             corrmatrix = np.corrcoef(r)
+            
+            
+#             [a,b]=np.where(corrmatrix > corr_threshold_recombination)
+#             nonsnp.extend(list(region[a[np.where(a!=b)]]))
+
+# nonsnp=np.unique(nonsnp)
+
+# corrmatrix[np.isnan(corrmatrix)]=0
+# fig,axs=plt.subplots()
+# hmap = axs.imshow(corrmatrix, cmap='Greys', interpolation='nearest')
+# fig.colorbar(hmap, ax=axs)
+        
+#%% Main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-i', dest='Input', type=str, help='Path to input candidate mutation table.',required=True)
+    parser.add_argument('-p', dest='Phylip', type=str, help='Path to output phylip.', required=True)
+    parser.add_argument('-o', dest='Output', type=str, help='Path to output tree.', required=True)
+    parser.add_argument('-n', dest='NameIDs', type=str, help='Path to output renaming file.', required=True)
+    parser.add_argument('-r', dest='RefGenome', type=str, help='Path to reference genome file.', required=True)
+    parser.add_argument('--min_cov', dest='MinCov', type=str, help='Minimum average coverage across positions to include a sample. Default=8.',required=False, default=8)
+    parser.add_argument('--min_maf', dest='MinMAF', type=str, help='Minimum major allele frequency to call a major allele. Default=0.85.', required=False, default=0.85)
+    parser.add_argument('--min_strand_cov', dest='MinStrandCov', type=str, help='Minimum coverage per strand to call a major allele. Default=2.', required=False, default=2)
+    parser.add_argument('--min_qual', dest='MinQual', type=str, help='Minimum mapping quality to call a major allele. Default=-30.',required=False,default=-30)
+    parser.add_argument('--min_presence_core', dest='MinCore', type=str, help='Minimum presence across samples to include a position. Default=0.9.', required=False,default=0.9)
+    parser.add_argument('--min_median_cov_samples', dest='MinCovSamples', type=str, help='Minimum median coverage across samples to include a position. Default=3.', required=False, default=3)
+    parser.add_argument('--filter_indels', dest='FilterIndels', type=str, help='Filter positions based on number of indels. Defaults to False.', required=False, default=False)
+    parser.add_argument('--remov_recomb', dest='Recomb', type=bool, help='Filter positions based on number of indels. Defaults to False.', required=False, default=False)
+
+
+    args = parser.parse_args()
+
+    if args.Recomb:
+        print('Remove recombinant regions: Yes')
+        
+    cmt2phylip(args.Input, args.Phylip, args.NameIDs, args.RefGenome,
+               min_cov_to_include=args.MinCov, min_maf_for_call=args.MinMAF,
+               min_strand_cov_for_call=args.MinStrandCov, min_qual_for_call=args.MinQual,
+               min_presence_core=args.MinCore,min_median_cov_samples=args.MinCovSamples,
+               consider_indels=args.FilterIndels, remov_recomb=args.Recomb)
+
+    generate_dnapars_tree(args.Phylip,args.Output,
+                          path_to_renaming_file=args.NameIDs)
+
+
+
+    
+
+    

--- a/phlame/countsCMT.py
+++ b/phlame/countsCMT.py
@@ -23,14 +23,14 @@ class CombinePositions():
     def __init__(self,
                  diversity_files,
                  path_to_ref):
-        
+
         self.diversity_files = diversity_files
         self.path_to_ref = path_to_ref
 
         self.chr_starts, self.genome_length, self.scaf_names = helper.genomestats(self.path_to_ref)
 
     def main(self):
-        
+
         variant_position_ls = []
         for file_ in self.diversity_files:
 
@@ -47,7 +47,7 @@ class CombinePositions():
 
     def combine_positions(self,
                           positions_files_ls):
-        
+
         #in_outgroup: booleans giving whether or not each sample is in the outgroup
         # print("Processing outgroup booleans...")
         # in_outgroup=[]
@@ -56,26 +56,26 @@ class CombinePositions():
         #         in_outgroup.append(line)
         # #Bool of samples to include
         # include = [not i for i in in_outgroup]
-        
+
         # #Get positions on reference genome
         # [self.chr_starts,self.genome_length,self.scaf_names] = ghf.genomestats(REFGENOMEDIRECTORY)
-        
+
         #Find positions with at least 1 fixed mutation relative to reference genome
         print('\n\nFinding positions with at least 1 fixed mutation...\n')
-        
+
         # positions_files_ls=[]
         # with open(path_to_positions_files) as file:
         #     for line in file:
         #         positions_files_ls.append(line)
-                
-        
+
+
         cp = self.generate_positions_snakemake(positions_files_ls)
         print(f"Found {len(cp)} positions where provided vcfs called a fixed variant in at least one in-group sample \n")
 
         #Todo: Add candidate positions manually
         #Combine different types of positions
         allp = cp
-                
+
         return allp
 
     def generate_positions_single_sample(self,
@@ -92,24 +92,24 @@ class CombinePositions():
         Returns:
             None.
 
-        '''    
+        '''
         # print(f"Currently examining the following vcf file: {path_to_variant_vcf}\n")
         # print(f"FQ threshold: {int(maxFQ)}")
-        
+
         # Initialize boolean vector for positions to include as candidate SNPs that
         # vary from the reference genome
         include = np.zeros((self.genome_length,1))
-        
-        
+
+
         f = gzip.open(path_to_variant_vcf,'rt')
-        
+
         for line in f:
             if not line.startswith("#"):
                 lineinfo = line.strip().split('\t')
-                
+
                 chromo=lineinfo[0]
                 position_on_chr=lineinfo[1] #1-indexed
-                
+
                 if len(self.chr_starts) == 1:
                     position=int(lineinfo[1])
                 else:
@@ -117,10 +117,10 @@ class CombinePositions():
                         raise ValueError("Scaffold name in vcf file not found in reference")
                     position=int(self.chr_starts[np.where(chromo==self.scaf_names)]) + int(position_on_chr)
                     #self.chr_starts begins at 0
-                    
+
                 alt=lineinfo[4]
                 ref=lineinfo[3]
-                
+
                 #only consider for simple calls (not indel, not ambiguous)
                 if (alt) and ("," not in alt) and (len(alt) == len(ref)) and (len(ref)==1):
                     #find and parse quality score
@@ -128,20 +128,20 @@ class CombinePositions():
                     xtinfo = xt.split(';')
                     entrywithFQ=[x for x in xtinfo if x.startswith('FQ')][0]
                     fq=entrywithFQ[entrywithFQ.index("=")+1:]
-                    
+
                     if float(fq) < maxFQ: #better than maxFQ
                         include[position-1]=1
                         #-1 converts position (1-indexed) to index
-        
+
         #+1 converts index back to position for p2chrpos
         var_positions=helper.p2chrpos(np.nonzero(include)[0]+1,self.chr_starts)
-        
+
         #save
         # with gzip.open(path_to_output_positions,"wb") as f:
         #     pickle.dump(Var_positions,f)
-            
+
         # print(f"{len(Var_positions)} variable positions found passing quality threshold")
-        
+
         return var_positions
 
 
@@ -159,7 +159,7 @@ class CombinePositions():
         if np.size(chrpos,0) < np.size(chrpos,1):
             chrpos=chrpos.T
             print('Reversed orientation of chrpos')
-            
+
         if len(self.chr_starts) == 1:
             p=chrpos[:,1]
         else:
@@ -169,42 +169,24 @@ class CombinePositions():
 
 
     def generate_positions_snakemake(self, positions_list):
-        '''Python version of generate_positions_snakemake.m
-        
-        Args:
-            paths_to_input_p_files (list): List of input positions files.
-            REFGENOMEDIRECTORY (str): Path to reference genome.
-
-        Returns:
-            combined_pos (arr): Vector of variable positions across samples.
-
-        '''
-                
-        # initialize vector to count occurrances of variants across samples
-        timesvariant = np.zeros((self.genome_length,1))
-        
-        # for i in range(len(positions_files_list)):
-        #     #load in positions array for sample
-        #     with gzip.open(positions_files_list[i].rstrip('\n'),"rb") as f:
-        #     # with open(positions_files_list[i].rstrip('\n'),"rb") as f:
-        #         positions=pickle.load(f)
-            
-        #     if len(positions)>2:
-        #         x=self.chrpos2index(positions)
-                
-        #         timesvariant[x]=timesvariant[x]+1
+    # initialize vector to count occurrances of variants across samples
+        timesvariant = np.zeros((self.genome_length, 1))
 
         for positions in positions_list:
-
             if len(positions) > 2:
-                x = self.chrpos2index(positions)
-                timesvariant[x] = timesvariant[x] + 1
-        
-        
-        #Keep positions that vary from the reference in at least one sample but
-        #that don't vary from the reference in ALL samples
-        combined_pos = np.where((timesvariant > 0) & (timesvariant < len(positions_list)))[0]
-        
+                x = self.chrpos2index(positions)   # x is 1..genome_length
+                xi = x - 1                         # convert to 0..genome_length-1 for numpy indexing
+
+                # (optional but safer) filter any weird values
+                xi = xi[(xi >= 0) & (xi < self.genome_length)]
+
+                timesvariant[xi] = timesvariant[xi] + 1
+
+        # combined_pos should be returned as 1-indexed positions to match later "p-1" usage
+        combined_pos = np.where(
+            (timesvariant > 0) & (timesvariant < len(positions_list))
+        )[0] + 1
+
         return combined_pos
 
 #%% pileup2diversity.py
@@ -218,7 +200,7 @@ class Pileup2Diversity:
                  path_to_variant_vcf_file=None,
                  path_to_pileup_file=None,
                  path_to_output_diversity=None):
-        
+
         self.__path_to_bam_file = path_to_bam_file
         self.__ref_file = path_to_ref
         self.path_to_output_diversity = path_to_output_diversity
@@ -234,7 +216,7 @@ class Pileup2Diversity:
         self.file_check()
 
         self.dependency_check()
-        
+
         self.process_data()
 
         if self.path_to_output_diversity:
@@ -247,37 +229,37 @@ class Pileup2Diversity:
         # Check that bam file exists
         if not os.path.exists(self.__path_to_bam_file):
             raise FileNotFoundError(f"Cannot find the file: {self.__path_to_bam_file} !")
-        
+
         if not os.path.exists(self.__ref_file):
             raise FileNotFoundError(f"Cannot find the reference genome file: {self.__ref_file} !")
-        
+
     def dependency_check(self):
-        
+
         if shutil.which("samtools") is None:
             raise RuntimeError("samtools is not installed or not in your PATH.")
-        
+
         if shutil.which("bcftools") is None:
             raise RuntimeError("bcftools is not installed or not in your PATH.")
 
     def process_data(self):
 
         with tempfile.TemporaryDirectory() as temp_dir:
-        
+
             self.__pileup_file = shlex.quote(os.path.join(temp_dir, 'temp.pileup'))
             self.__vcf_tmp_file = shlex.quote(os.path.join(temp_dir, 'temp.vcf.tmp'))
             self.__vcf_file = shlex.quote(os.path.join(temp_dir, 'temp.vcf.gz'))
             self.__variant_vcf_file = shlex.quote(os.path.join(temp_dir, 'temp.variant.vcf.gz'))
 
-                        
+
             print("Running samtools mpileup...")
             print(f"samtools mpileup -q30 -x -s -O -d3000 "+ \
                            f"-f {shlex.quote(self.__ref_file)} "+ \
                            f"{shlex.quote(self.__path_to_bam_file)} > {self.__pileup_file}")
-            
+
             subprocess.run(f"samtools mpileup -q30 -x -s -O -d3000 "+ \
                            f"-f {shlex.quote(self.__ref_file)} "+ \
                            f"{shlex.quote(self.__path_to_bam_file)} > {self.__pileup_file}", shell=True)
-            
+
             print("Running bcftools mpileup...")
             print(f"bcftools mpileup -q30 -d3000 "+ \
                            f"-f {shlex.quote(self.__ref_file)} "+ \
@@ -285,15 +267,15 @@ class Pileup2Diversity:
             subprocess.run(f"bcftools mpileup -q30 -d3000 "+ \
                             f"-f {shlex.quote(self.__ref_file)} "+ \
                             f"{shlex.quote(self.__path_to_bam_file)} > {self.__vcf_tmp_file}", shell=True)
-            
+
             self.vcf_check(self.__vcf_tmp_file)
-            
+
             print("Running bcftools call...")
             print(f"bcftools call -c -Oz -o {self.__vcf_file} "+ \
                            f"{self.__vcf_tmp_file} --ploidy 1")
             subprocess.run(f"bcftools call -c -Oz -o {self.__vcf_file} "+ \
                             f"{self.__vcf_tmp_file} --ploidy 1", shell=True)
-            
+
             print("Running bcftools view...")
             print(f"bcftools view -Oz -v snps -q .75 {self.__vcf_file} > {self.__variant_vcf_file}")
             subprocess.run(f"bcftools view -Oz -v snps -q .75 {self.__vcf_file} > {self.__variant_vcf_file}", shell=True)
@@ -315,12 +297,12 @@ class Pileup2Diversity:
                                         self.chr_starts,
                                         self.genome_length,
                                         self.scaf_names)
-        
+
             self.quals_sample = Vcf2Quals.vcf_to_quals(self.__vcf_file,
                                                 self.chr_starts,
                                                 self.genome_length,
                                                 self.scaf_names)
-            
+
             self.variant_pos = self.generate_positions_single_sample(self.__variant_vcf_file)
 
     @staticmethod
@@ -352,16 +334,16 @@ class Pileup2Diversity:
     def write_diversity(data,
                         quals_sample,
                         variant_pos, path_to_output_diversity):
-        
+
         print(f"Saving data to {path_to_output_diversity}...")
-        
+
         diversity = {'data': data,
                      'quals': quals_sample,
                      'variant_pos': variant_pos}
-        
+
 
         with gzip.open(path_to_output_diversity, 'wb') as f:
-            
+
             pickle.dump(diversity, f)
 
     @staticmethod
@@ -373,18 +355,18 @@ class Pileup2Diversity:
         Args:
             input_pileup (str): Path to input pileup file.
             path_to_ref (str): Path to reference genome file
-            
+
         """
         #parameters
         nts = 'ATCGatcg'
         nts_dict = {'A':0,'T':1,'C':2,'G':3,'a':4,'t':5,'c':6,'g':7}
         num_fields=10
-        indelregion=3 #region surrounding each p where indels recorded 
+        indelregion=3 #region surrounding each p where indels recorded
         #get reference genome + position information
-        
+
         #initialize output array
         data = np.zeros((genome_length,num_fields)) #format [[A T C G  a t c g],[...]]
-        
+
         #read in mpileup file
         print(f"Reading input file: {path_to_pileup}")
 
@@ -392,23 +374,23 @@ class Pileup2Diversity:
         print(f"Number of lines in pileup file: {num_lines}")
         if num_lines < 1:
             raise ValueError("Pileup file is empty!")
-        
+
         mpileup = open(path_to_pileup)
-        
+
         #####
         loading_bar=0
-        
+
         for line in mpileup:
-            
+
             # loading_bar+=1
             # if loading_bar % 50000 == 0:
             #     print('.')
-            
+
             lineinfo = line.strip().split('\t')
-            
+
             #holds info for each position before storing in data
             temp = np.zeros((num_fields))
-            
+
             chromo = lineinfo[0]
             #position (absolute)
             if len(chr_starts) == 1:
@@ -418,33 +400,33 @@ class Pileup2Diversity:
                     raise ValueError("Scaffold name in pileup file not found in reference")
                 position=int(chr_starts[np.where(chromo==scaf_names)]) + int(lineinfo[1])
                 #chr_starts begins at 0
-            
+
             #ref allele
             ref=nts_dict[lineinfo[2]] # convert to 0123
             if ref > 4:
                 ref = ref - 4
-            
+
             #calls info
             # calls=np.fromstring(lineinfo[4], dtype=np.int8) #to ASCII
             # Original line spits out a warning
-            calls=np.array([ord(l) for l in lineinfo[4]]) 
+            calls=np.array([ord(l) for l in lineinfo[4]])
             # calls=np.array([ord(l) for l in lineinfo[4]]) #ASCII
-            
+
             #find starts of reads ('^' in mpileup)
             startsk=np.where(calls==94)[0]
             for k in startsk:
-                calls[k:k+2]=-1 
+                calls[k:k+2]=-1
                 #remove mapping character, absolutely required because the next chracter could be $
-            
+
             #find ends of reads ('$' in mpileup)
             endsk=np.where(calls==36)[0]
             calls[endsk]=-1
-            
+
             #find indels + calls from reads supporting indels ('+-')
             indelk = np.where((calls==43) | (calls==45))[0]
             for k in indelk:
                 if (calls[k+2] >=48) and (calls[k+2] < 58): #2 digit indel (size > 9 and < 100)
-                    indelsize=int(chr(calls[k+1]) + chr(calls[k+2])) 
+                    indelsize=int(chr(calls[k+1]) + chr(calls[k+2]))
                     #indelsize=str2double(char(calls(k+1:k+2))); MATLAB
                     indeld=2
                 else: #1 digit indel (size <= 9)
@@ -471,7 +453,7 @@ class Pileup2Diversity:
 
                 #remove indel info from counting
                 calls[k:(k+1+indeld+indelsize)] = -1 #don't remove base that precedes an indel
-            
+
             #replace reference matches (.,) with their actual calls
             if ref >=0:
                 calls[np.where(calls==46)[0]]=ord(nts[ref]) #'.'
@@ -481,25 +463,25 @@ class Pileup2Diversity:
             simplecalls=calls[np.where(calls>0)[0]]
             #simplecalls is a tform of calls where each calls position
             #corresponds to its position in bq, mq, td
-            
+
             #count how many of each nt and average scores
 
             for nt in range(8):
                 nt_count=np.count_nonzero(simplecalls == ord(nts[nt]))
                 if nt_count > 0:
                     temp[nt]=nt_count
-            
+
             #-1 is needed to turn 1-indexed mpileup to 0-indexed arr
             data[position-1,0:8]=temp[0:8]
-            
+
         #######
         mpileup.close()
-        
+
         #calc coverage
         coverage=np.sum(data[:,0:8],1)
-        
+
         return data, coverage
-    
+
     def generate_positions_single_sample(self,
                                          path_to_variant_vcf,
                                          maxFQ=-30):
@@ -514,24 +496,24 @@ class Pileup2Diversity:
         Returns:
             None.
 
-        '''    
+        '''
         # print(f"Currently examining the following vcf file: {path_to_variant_vcf}\n")
         # print(f"FQ threshold: {int(maxFQ)}")
-        
+
         # Initialize boolean vector for positions to include as candidate SNPs that
         # vary from the reference genome
         include = np.zeros((self.genome_length,1))
-        
-        
+
+
         f = gzip.open(path_to_variant_vcf,'rt')
-        
+
         for line in f:
             if not line.startswith("#"):
                 lineinfo = line.strip().split('\t')
-                
+
                 chromo=lineinfo[0]
                 position_on_chr=lineinfo[1] #1-indexed
-                
+
                 if len(self.chr_starts) == 1:
                     position=int(lineinfo[1])
                 else:
@@ -539,10 +521,10 @@ class Pileup2Diversity:
                         raise ValueError("Scaffold name in vcf file not found in reference")
                     position=int(self.chr_starts[np.where(chromo==self.scaf_names)]) + int(position_on_chr)
                     #self.chr_starts begins at 0
-                    
+
                 alt=lineinfo[4]
                 ref=lineinfo[3]
-                
+
                 #only consider for simple calls (not indel, not ambiguous)
                 if (alt) and ("," not in alt) and (len(alt) == len(ref)) and (len(ref)==1):
                     #find and parse quality score
@@ -550,20 +532,20 @@ class Pileup2Diversity:
                     xtinfo = xt.split(';')
                     entrywithFQ=[x for x in xtinfo if x.startswith('FQ')][0]
                     fq=entrywithFQ[entrywithFQ.index("=")+1:]
-                    
+
                     if float(fq) < maxFQ: #better than maxFQ
                         include[position-1]=1
                         #-1 converts position (1-indexed) to index
-        
+
         #+1 converts index back to position for p2chrpos
         var_positions=helper.p2chrpos(np.nonzero(include)[0]+1,self.chr_starts)
-        
+
         #save
         # with gzip.open(path_to_output_positions,"wb") as f:
         #     pickle.dump(Var_positions,f)
-            
+
         # print(f"{len(Var_positions)} variable positions found passing quality threshold")
-        
+
         return var_positions
 
 
@@ -583,24 +565,24 @@ class Vcf2Quals:
 
         Returns:
             None.
-            
+
         '''
 
         #initialize vector to record quals
         quals = np.zeros((genome_length,1), dtype=int)
-        
+
         print(f"Loaded: {path_to_vcf_file}")
         file = gzip.open(path_to_vcf_file,'rt') #load in file
-        
+
         for line in file:
             if not line.startswith("#"):
                 lineinfo = line.strip().split('\t')
-                
+
                 #Note: not coding the loading bar in the matlab script
-                
+
                 chromo=lineinfo[0]
                 position_on_chr=lineinfo[1] #1-indexed
-                
+
                 if len(chr_starts) == 1:
                     position=int(lineinfo[1])
                 else:
@@ -608,10 +590,10 @@ class Vcf2Quals:
                         raise ValueError("Scaffold name in vcf file not found in reference")
                     position=int(chr_starts[np.where(chromo==scaf_names)]) + int(position_on_chr)
                     #chr_starts begins at 0
-                    
+
                 alt=lineinfo[4]
                 ref=lineinfo[3]
-                
+
                 #only consider for simple calls (not indel, not ambiguous)
                 if (alt) and ("," not in alt) and (len(alt) == len(ref)) and (len(ref)==1):
                     #find and parse quality score
@@ -619,14 +601,14 @@ class Vcf2Quals:
                     xtinfo = xt.split(';')
                     entrywithFQ=[x for x in xtinfo if x.startswith('FQ')][0]
                     fq=float(entrywithFQ[entrywithFQ.index("=")+1:])
-                    
+
                     #If already a position wiht a stronger FQ here, don;t include this
                     #More negative is stronger
                     if fq < quals[position-1]:
-                        quals[position-1]=round(fq) 
+                        quals[position-1]=round(fq)
                             #python int(fq) will by default round down, round matches matlab behavior
                             #-1 important to convert position (1-indexed) to python index
-        
+
         return quals
 
 #%%
@@ -638,9 +620,9 @@ class Case():
                  path_to_diversity_files,
                  path_to_ref,
                  path_to_out_cmt):
-        
+
         self.path_to_sample_names_file = path_to_sample_names
-        
+
         self.path_to_diversity_files = path_to_diversity_files
         self.diversity_files = helper.parse_file_list(self.path_to_diversity_files,
                                                       check_files=True)
@@ -693,7 +675,7 @@ class Case():
             self.counts[:, :, i] = data[self.p - 1, 0:dim].T  # -1 convert position to index
             self.indel_counter[:, :, i] = data[self.p - 1, 8:10].T  # Num reads supporting indels and reads supporting deletions
             self.quals[:, i] = quals_sample[self.p - 1]  # -1 is to convert position to index
-
+        
         self.write_CMT()
 
     def QC_plots(self):
@@ -708,26 +690,27 @@ class Case():
         # =============================================================================
 
         coverage = self.counts.sum(axis=0)
+        print('Coverage:')
+        print(coverage)
+        #fig = phlame_plot.plot_coverage_hist(coverage,
+        #                                     self.minimum_coverage)
 
-        fig = phlame_plot.plot_coverage_hist(coverage,
-                                             self.minimum_coverage)
-        
-        fig.savefig(self.path_to_out_cmt + '.sample_coverage.pdf',
-                    bbox_inches='tight', format='pdf')
-        
+        #fig.savefig(self.path_to_out_cmt + '.sample_coverage.pdf',
+        #            bbox_inches='tight', format='pdf')
+
         # =========================================================================
         #  Filter by position
         # =========================================================================
 
-        [maNT, maf, minorNT, minorAF] = helper.mant(counts)
+        [maNT, maf, minorNT, minorAF] = helper.mant(self.counts)
 
-        fig = plot_position_presence(np.count_nonzero(maNT, axis=1), 
-                                     self.min_presence_core,
-                                     'Presence (not N) across samples')
-        
-        fig.savefig(self.path_to_out_cmt + '.position_presence.pdf',
-                    bbox_inches='tight', format='pdf')
-        
+        #fig = plot_position_presence(np.count_nonzero(maNT, axis=1),
+        #                             self.min_presence_core,
+        #                             'Presence (not N) across samples')
+
+        #fig.savefig(self.path_to_out_cmt + '.position_presence.pdf',
+        #            bbox_inches='tight', format='pdf')
+
         # Booleans are all INCLUSION criteria!
         # Must be present (not N) in some fraction of samples
         min_core_bool = ( np.count_nonzero(maNT, axis=1) >= self.min_presence_core )
@@ -737,14 +720,13 @@ class Case():
         # =============================================================================
         #  Filter by sample
         # =============================================================================
-        
+
         fig = plot_samples_hist(1-(np.count_nonzero(goodcalls, axis=0)/len(goodcalls)),
                                 float(filterby_sample['max_frac_ambiguous_pos']))
         fig.show()
 
         fig.savefig(self.path_to_out_cmt + '.sample_breadth.pdf',
                     bbox_inches='tight', format='pdf')
-        
 
 
 
@@ -755,7 +737,8 @@ class Case():
 
 
 
-        
+
+
 
 
 

--- a/phlame/helper_functions.py
+++ b/phlame/helper_functions.py
@@ -154,7 +154,10 @@ class CountsMat():
             if len(self.chr_starts) == 1:
                 position=int(lineinfo[1])
             else:
-                position=int(self.chr_starts[np.where(chromo==self.scaf_names)]) + int(lineinfo[1])
+                scaf_idx = np.where(self.scaf_names == chromo)[0]
+                if scaf_idx.size == 0:
+                    raise ValueError(f"Contig {chromo} not found in reference scaffolds.")
+                position=int(self.chr_starts[scaf_idx[0]]) + int(lineinfo[1])
                 #chr_starts begins at 0
             pidx = np.searchsorted(allpos, position) # index of position on allpos
             
@@ -467,7 +470,7 @@ def read_clades_file(path_to_clades_file, uncl_marker):
         if clade==uncl_marker:
             continue
         
-        isclade_bool = np.in1d(clade_ids[:,1], clade)
+        isclade_bool = np.isin(clade_ids[:,1], clade)
         clade_samples = clade_ids[isclade_bool,0].tolist()
         
         clades_dct[clade] = clade_samples

--- a/phlame/makedb.py
+++ b/phlame/makedb.py
@@ -18,510 +18,572 @@ import phlame.helper_functions as helper
 #%% FXNs
 
 class MakeDB():
-    '''
-    Main controller of the makedb step.
-    '''
+	'''
+	Main controller of the makedb step.
+	'''
 
-    def __init__(self, 
-                 path_to_cmt,
-                 path_to_tree,
-                 path_to_output_clades,
-                 path_to_output_db,
-                 outgroup_str=None,
-                 path_to_input_clades=None,
-                 min_branch_len=100,
-                 min_nsamples=3,
-                 min_support=0.75,
-                 min_snps=10,
-                 maxn=0.1,
-                 core=0.9,
-                 min_maf_for_call=0.75, 
-                 min_strand_cov_for_call=2,
-                 max_qual_for_call=-30,
-                 max_frac_ambiguous=0.5,
-                 max_outgroup=0.1,
-                 midpoint_root=False
-                 ):
+	def __init__(self,
+				 path_to_cmt,
+				 path_to_tree,
+				 path_to_output_clades,
+				 path_to_output_db,
+				 path_to_out_tree=None,
+				 outgroup_str=None,
+				 path_to_input_clades=None,
+				 min_branch_len=100,
+				 min_nsamples=3,
+				 min_support=0.75,
+				 min_snps=10,
+				 maxn=0.1,
+				 core=0.9,
+				 min_maf_for_call=0.75,
+				 min_strand_cov_for_call=2,
+				 max_qual_for_call=-30,
+				 max_frac_ambiguous=0.5,
+				 max_outgroup=0.1,
+				 midpoint_root=False
+				 ):
 
-        self.__path_to_cmt = path_to_cmt
-        self.__path_to_tree = path_to_tree
-        self.path_to_output_clades = path_to_output_clades
-        self.__path_to_output_db = path_to_output_db
-        
-        self.path_to_input_clades = path_to_input_clades
+		self.__path_to_cmt = path_to_cmt
+		self.__path_to_tree = path_to_tree
+		self.path_to_output_clades = path_to_output_clades
+		self.__path_to_output_db = path_to_output_db
+		self.__path_to_out_tree = path_to_out_tree
 
-        self.outgroup_str = outgroup_str
+		self.path_to_input_clades = path_to_input_clades
 
-        # Clade calling parameters
-        self.min_branch_len = min_branch_len
-        self.min_nsamples = min_nsamples
-        self.min_support = min_support
-        self.midpoint_root = midpoint_root
-        
-        # Database parameters
-        self.min_snps = min_snps
-        self.maxn = maxn
-        self.core = core
+		self.outgroup_str = outgroup_str
 
-        self.max_outgroup = max_outgroup
+		# Clade calling parameters
+		self.min_branch_len = min_branch_len
+		self.min_nsamples = min_nsamples
+		self.min_support = min_support
+		self.midpoint_root = midpoint_root
 
-        self.min_maf_for_call = min_maf_for_call
-        self.min_strand_cov_for_call = min_strand_cov_for_call
-        self.max_qual_for_call = max_qual_for_call
-        self.max_frac_ambiguous = max_frac_ambiguous
+		# Database parameters
+		self.min_snps = min_snps
+		self.maxn = maxn
+		self.core = core
 
-    def readin(self):
-        '''
-        Main function to read in files
-        '''
+		self.max_outgroup = max_outgroup
 
-        self.CMT = helper.CandidateMutationTable(self.__path_to_cmt)
-        
-        self.sample_names = helper.rphylip(self.CMT.sample_names)
-        
-        self.tree = ete3.Tree(self.__path_to_tree, format=0)
-        
-        if self.midpoint_root:
-            midpoint_root = self.tree.get_midpoint_outgroup()
-            self.tree.set_outgroup(midpoint_root)
-        
-        self.tree.standardize()
-            
-    def main(self):
-        
-        # =========================================================================
-        # Read in files
-        # =========================================================================
-        print('Reading in files...')
-        
-        self.readin()
+		self.min_maf_for_call = min_maf_for_call
+		self.min_strand_cov_for_call = min_strand_cov_for_call
+		self.max_qual_for_call = max_qual_for_call
+		self.max_frac_ambiguous = max_frac_ambiguous
 
-        # =========================================================================
-        # Clade caller
-        # =========================================================================
+	def readin(self):
+		'''
+		Main function to read in files
+		'''
 
-        if self.path_to_input_clades:
+		self.CMT = helper.CandidateMutationTable(self.__path_to_cmt)
 
-            print(f'Using information from the following file to define clades:')
-            print(os.path.basename(self.path_to_input_clades))
-            candidate_clades, candidate_clade_names = helper.read_clades_file(self.path_to_input_clades, uncl_marker='-1')
+		self.sample_names = helper.rphylip(self.CMT.sample_names)
 
-        else:
-            
-            self.call_clades_check()
-            
-            candidate_clades, candidate_clade_names, new_tree = self.call_clades()
+		self.tree = ete3.Tree(self.__path_to_tree, format=0)
 
-            # Write clade IDs
-            self.write_cladeIDs(candidate_clades,
-                                self.path_to_output_clades)
-        
-        # =========================================================================
-        # maNT calls
-        # =========================================================================
+		if self.midpoint_root:
+			midpoint_root = self.tree.get_midpoint_outgroup()
+			self.tree.set_outgroup(midpoint_root)
 
-        self.maNT, maf, _, _ = helper.mant(self.CMT.counts)
+		self.tree.standardize()
 
-        # =========================================================================
-        # Define ingroup and outgroup
-        # =========================================================================
+	def main(self):
 
-        self.define_outgroup()
-        
-        # =========================================================================
-        # Do pre-filtering of allele calls
-        # =========================================================================
+		# =========================================================================
+		# Read in files
+		# =========================================================================
+		print('Reading in files...')
 
-        # Filter for only core genome positions
-        is_core_genome = np.count_nonzero(self.ingroup, axis=1)/len(self.ingroup[1]) >= self.core
-        core_maNT = self.ingroup[is_core_genome]
-        core_pos = self.CMT.pos[is_core_genome]
-        print(f"Number of core positions: {len(core_pos)}/{len(self.CMT.pos)}")
-        if np.count_nonzero(is_core_genome) < len(is_core_genome)/5:
-            print(f'Warning: Less than 20% of positions are core to > {self.core*100}% of samples!')
-            print(f'Consider lowering the core genome threshold or checking the input data.')
+		self.readin()
 
-        # Mask ambiguous allele calls
-        calls = np.copy(core_maNT)
-        # calls[ quals[is_core_genome] > self.max_qual_for_call ] = 0
-        # calls[ ingroup_maf[is_core_genome] < self.min_maf_for_call ] = 0
+		# =========================================================================
+		# Clade caller
+		# =========================================================================
 
-        # Mask samples with too many ambiguous allele calls
-        fracNs_bool = ( ((calls>0).sum(axis=0)/len(calls)) >= self.max_frac_ambiguous )
-        
-        if np.count_nonzero(~fracNs_bool) > 0:
-            print('The following samples have too many ambiguous allele calls and will not be considered:')
-            print('\n'.join(self.ingroup_sample_names[~fracNs_bool]))
+		if self.path_to_input_clades:
 
-        if np.count_nonzero(fracNs_bool) < 2:
-            raise Warning('After filtering, there are fewer than 3 samples!')
+			print(f'Using information from the following file to define clades:')
+			print(os.path.basename(self.path_to_input_clades))
+			candidate_clades, candidate_clade_names = helper.read_clades_file(self.path_to_input_clades, uncl_marker='-1')
+			tree_to_write = self.tree
 
-        # Moving this to inside the unaminous_to_clade function
-        # calls = calls[:,mask_fracNs]
-        # ingroup_sample_names = ingroup_sample_names[mask_fracNs]
+		else:
 
-        # =========================================================================
-        # Get csSNPs for every clade
-        # =========================================================================
-        
-        #Call csSNPs
-        print('Getting unanimous alleles...')
-        unanimous_alleles = unanimous_to_clade(calls, self.ingroup_sample_names,
-                                               candidate_clades, candidate_clade_names,
-                                               self.maxn, self.max_frac_ambiguous)
+			self.call_clades_check()
 
-        print('Getting unique alleles...')
-        candidate_css = unique_to_clade(calls, unanimous_alleles, self.ingroup_sample_names,
-                                        candidate_clades, candidate_clade_names)
-        
-        # Remove positions aligning to too many outgroup genomes
-        if len(self.outgroup_sample_names) > 0:
-            print('Removing positions present in outgroup genomes...')
-            max_outgroup_bool = ( (np.count_nonzero(self.outgroup, axis=1)/len(self.outgroup[1])) 
-                                 >= self.max_outgroup )
+			candidate_clades, candidate_clade_names, new_tree = self.call_clades()
+			tree_to_write = new_tree
 
-            candidate_css[max_outgroup_bool[is_core_genome]] = 0
-            print(f"Removed {np.count_nonzero(max_outgroup_bool[is_core_genome])}/{len(candidate_css)} positions in present >{self.max_outgroup*100}% of outgroup genomes")
+			# Write clade IDs
+			self.write_cladeIDs(candidate_clades,
+								self.path_to_output_clades)
 
-        # =========================================================================
-        #  Remove clades without enough csSNPs
-        # =========================================================================
-        
-        is_cs_clade = np.count_nonzero(candidate_css,0) > self.min_snps
-        
-        cssnps_arr = candidate_css[:,is_cs_clade]
-        clade_names = candidate_clade_names[is_cs_clade]
-        
-        if np.sum(~is_cs_clade) > 0:
-            print(f"The following clades had fewer than {self.min_snps} specific SNPs and will be removed:")
-            for cname in candidate_clade_names[~is_cs_clade]:
-                print(f"{cname}\n")
-       
-        # Trim cssnps_arr to just include positions with a csSNP
-        cssnps = cssnps_arr[np.count_nonzero(cssnps_arr,1) > 0]
-        cssnp_pos = core_pos[np.count_nonzero(cssnps_arr,1) > 0]
+		if self.__path_to_out_tree:
+			self.write_tree(tree_to_write)
 
-        # =========================================================================
-        #  Report results
-        # =========================================================================
+		# =========================================================================
+		# maNT calls
+		# =========================================================================
 
-        print('Classifier results:')
-        for c in range(len(clade_names)):
-            print('Clade ' + clade_names[c] + ': ' + str(np.count_nonzero(cssnps[:,c])) + ' csSNPs found')
-        
-        # =========================================================================
-        #  Save classifier object
-        # =========================================================================
-        
-        with gzip.open(self.__path_to_output_db, 'wb') as f:
-            
-            pickle.dump({'clades':candidate_clades,
-                        'clade_names':clade_names,
-                        'cssnps':cssnps,
-                        'cssnp_pos':cssnp_pos}, f)
+		self.maNT, maf, _, _ = helper.mant(self.CMT.counts)
 
-    def parse_outgroup(self):
+		# =========================================================================
+		# Define ingroup and outgroup
+		# =========================================================================
 
-        if self.outgroup_str:
+		self.define_outgroup()
 
-            self.outgroup_ls = [item.strip() for item in self.outgroup_str.split(",")]
-            
-            # Check that all outgroup genomes are present in candidate mutation table
-            if not np.array([genome in self.sample_names for genome in self.outgroup_ls]).all():
-                raise Exception('The following outgroup genomes are not present in the candidate mutation table: ' +
-                                ', '.join([genome for genome in self.outgroup_ls if genome not in self.sample_names]))
-            
-            # outgroup_bool = np.in1d(self.sample_names, self.outgroup_ls)
-        
-            # # Check if any outgroup genomes are not in sample_names
-            # if np.sum(outgroup_bool) < len(self.outgroup_ls):
-            #     print('Warning: The following outgroup genomes could not be found in the candidate mutation table. Will proceed anyway. ' +
-            #           '\n'.join([genome for genome in self.outgroup_ls if genome not in self.sample_names]))
-                
-            # if np.sum(outgroup_bool) == 0:
-            #     raise Exception('None of the outgroup genomes given are present!')
+		# =========================================================================
+		# Do pre-filtering of allele calls
+		# =========================================================================
 
-        else:
-            self.outgroup_ls = []
+		# Filter for only core genome positions
+		is_core_genome = np.count_nonzero(self.ingroup, axis=1)/len(self.ingroup[1]) >= self.core
+		core_maNT = self.ingroup[is_core_genome]
+		core_pos = self.CMT.pos[is_core_genome]
+		print(f"Number of core positions: {len(core_pos)}/{len(self.CMT.pos)}")
+		if np.count_nonzero(is_core_genome) < len(is_core_genome)/5:
+			print(f'Warning: Less than 20% of positions are core to > {self.core*100}% of samples!')
+			print(f'Consider lowering the core genome threshold or checking the input data.')
 
+		# Mask ambiguous allele calls
+		calls = np.copy(core_maNT)
+		#JSB: these are currently turned off and not doing anything
+		# calls[ quals[is_core_genome] > self.max_qual_for_call ] = 0
+		# calls[ ingroup_maf[is_core_genome] < self.min_maf_for_call ] = 0
 
-    def define_outgroup(self):
+		#JSB: fixed logic. old lines:
 
-        self.parse_outgroup()
-        
-        # Define outgroup
-        outgroup_bool = np.in1d(self.sample_names, self.outgroup_ls)
-        
-        if np.sum(outgroup_bool) == 0:
-            self.ingroup = self.maNT
-            self.ingroup_sample_names = self.sample_names
-            self.outgroup = np.array([])
-            self.outgroup_sample_names = np.array([])
-        
-        else:
-            self.ingroup = self.maNT[:,~outgroup_bool]
-            self.ingroup_sample_names = self.sample_names[~outgroup_bool]
-            self.outgroup = self.maNT[:,outgroup_bool]
-            self.outgroup_sample_names = self.sample_names[outgroup_bool]
+		# # Mask samples with too many ambiguous allele calls
+		# fracNs_bool = ( ((calls>0).sum(axis=0)/len(calls)) >= self.max_frac_ambiguous )
 
+		# if np.count_nonzero(~fracNs_bool) > 0:
+		# 	print('The following samples have too many ambiguous allele calls and will not be considered:')
+		# 	print('\n'.join(self.ingroup_sample_names[~fracNs_bool]))
 
-    def call_clades_check(self):
-        '''
-        Check that the parameters passed to call_clades make sense
-        '''
+		# if np.count_nonzero(fracNs_bool) < 2:
+		# 	raise Warning('After filtering, there are fewer than 3 samples!')
 
-        dists = []
-        for node in self.tree.traverse("preorder"):
-            dists.append(node.dist)
+		# Moving this to inside the unaminous_to_clade function
+		# calls = calls[:,mask_fracNs]
+		# ingroup_sample_names = ingroup_sample_names[mask_fracNs]
 
-        if self.min_branch_len > max(dists):
-            raise IOError(f'Minimum branch length threshold ({self.min_branch_len}) is longer than the longest branch in the tree!')
-        
-        if len(self.tree.get_leaf_names()) < self.min_nsamples*2:
-            raise IOError(f"There are fewer than {self.min_nsamples} samples in the tree. It will not be possible to call more than one clade (Minimum number of samples in a clade is {self.min_nsamples}).")
-        
+		#JSB: new lines:
+		# Mask samples with too many ambiguous allele calls
+		# Compute the fraction of ambiguous calls (Ns) per sample
+		fracNs = (calls == 0).sum(axis=0) / calls.shape[0]
+		# Keep samples whose ambiguous fraction does not exceed max_frac_ambiguous
+		fracNs_bool = fracNs <= self.max_frac_ambiguous
 
-    def call_clades(self):
-        '''
-        Call candidate clades for every branch of tree passing thresholds.
-        '''
-        
-        # Initialize outputs
-        good_nodes=[] # candidate clades
-        clade_name=[] # name of candidate clade
-        tips_sets=[]; tips_ls=[] # isolates defining clades
-        
-        #Go through nodes 
-        for node in self.tree.traverse("preorder"):
-            
-            # Cut clades at long enough branch lengths and bootstrap values
-            if node.is_leaf() is False and node.dist is not None \
-                and node.dist >= self.min_branch_len \
-                and len(node.get_leaves()) >= self.min_nsamples \
-                and node.support >= self.min_support:
-                
-                
-                good_nodes.append(node) # Save node object
-                
-                clade_name.append('tmp') # Create temp. name for naming function
-                
-                leaf_names = []
-                for leaf in node.iter_leaves():
-                    leaf_names.append(leaf.name)
-                
-                tips_sets.append(set(leaf_names)) # Save tip names as a set
-                
-                tips_ls.append(leaf_names)
+		if np.count_nonzero(~fracNs_bool) > 0:
+			print('The following samples have too many ambiguous allele calls and will not be considered:')
+			print('\n'.join(self.ingroup_sample_names[~fracNs_bool]))
 
-        def fill_clade_names(parent, parent_name):
-            '''
-            Name daughter clades iteratively according to their parent 
-            and create tree object reflecting structure.
-            
-            Naming follows this logic:
-            1. Starting at the root, find the first daughter node (dnode) for 
-            which dnode is a subset of the parent and only the parent 
-            (i.e an immediate descendant)
-            2. Name it with 'parent_name'.1
-            3. Recur onto dnode (first daughter of 'parent'.1 will be 'parent'.1.1)
-            4. Then increase number (1->2)
-            5. Find the next dnode for which dnode is a subset of the parent 
-            and only the parent. (i.e. sister to 'parent_name'.1). These will 
-            thus be named 'parent'.2, 'parent'.3, etc.
-            6. Continue until all names are filled
-                
-            '''
-            number=1
-            # Iterate through goodnodes
-            for i in range(len(tips_sets)):
-                
-                # Is this goodnode a subset of the parent and only the parent?
-                if tips_sets[i].issubset(parent) \
-                    and sum([tips_sets[i].issubset(tips_sets[c]) for c in range(len(tips_sets)) if clade_name[c] == 'tmp']) == 1: 
-                    #^ugly
-                        
-                    # Name it the parent name + number
-                    clade_name[i] = parent_name + '.' + str(number)
-                    # Then, recur onto this node
-                    fill_clade_names(tips_sets[i], clade_name[i])
-                    # Then increase number
-                    number = number+1
-                
-        # Begin at the root
-        fill_clade_names(set(self.tree.get_leaf_names()), 'C')
-        
-        #### Create ete3 graph structure from clade names ####
-        # Note that this is NOT a binary tree and can have multifurcations + internal nodes    
-        # graph = ete3.Tree()
-        # for name in clade_name:
-        #     # If clade is a direct descendant from root
-        #     if name.rsplit('.', 1)[0] == 'C':
-        #         # Add clade as child of root
-        #         graph.add_child(name=name)
-        #     # If there is another ancestor
-        #     else:
-        #         # Search for the ancestor and add clade as a child of that
-        #         graph.search_nodes(name=name.rsplit('.', 1)[0])[0].add_child(name=name)
-    
-    
-        # Make clades dict object
-        clades = {}
-        for name, tips in zip(clade_name, tips_ls):
-            clades[name] = tips
+		# Require at least one sample to proceed
+		if np.count_nonzero(fracNs_bool) < 1:
+			warnings.warn('After filtering, there are no samples with sufficient unambiguous calls.')
 
-        # Annotate phylogenetic tree with updated clade names
-        new_tree = self.tree.copy()
-        for new_node in new_tree.traverse('preorder'):
-            if not new_node.is_leaf():
-                new_node_tips = new_node.get_leaf_names()
-                #Do tips of this node match good_nodes?
-                if new_node_tips in tips_ls:
-                    # print("match")
-                    new_node.name = clade_name[tips_ls.index(new_node_tips)]
-                else:
-                    new_node.name=None
+		calls = calls[:, fracNs_bool]
+		self.ingroup_sample_names = self.ingroup_sample_names[fracNs_bool]
+		#return
+		# JSB: end edit
+
+		# =========================================================================
+		# Get csSNPs for every clade
+		# =========================================================================
+
+		#Call csSNPs
+		print('Getting unanimous alleles.....')
+		unanimous_alleles = unanimous_to_clade(calls, self.ingroup_sample_names,
+											   candidate_clades, candidate_clade_names,
+											   self.maxn, self.max_frac_ambiguous)
+		print(np.count_nonzero(unanimous_alleles))
+		print('Unanimous alleles per clade:', np.count_nonzero(unanimous_alleles, axis=0))
+		print('Getting unique alleles...')
+		candidate_css = unique_to_clade(calls, unanimous_alleles, self.ingroup_sample_names,
+										candidate_clades, candidate_clade_names)
+		print(np.count_nonzero(candidate_css, axis=0))
+		# Remove positions aligning to too many outgroup genomes
+		if len(self.outgroup_sample_names) > 0:
+			print('Removing positions present in outgroup genomes...')
+			max_outgroup_bool = ( (np.count_nonzero(self.outgroup, axis=1)/len(self.outgroup[1]))
+								 >= self.max_outgroup )
+
+			candidate_css[max_outgroup_bool[is_core_genome]] = 0
+			print(f"Removed {np.count_nonzero(max_outgroup_bool[is_core_genome])}/{len(candidate_css)} positions in present >{self.max_outgroup*100}% of outgroup genomes")
+
+		# =========================================================================
+		#  Remove clades without enough csSNPs
+		# =========================================================================
+
+		is_cs_clade = np.count_nonzero(candidate_css,0) > self.min_snps
+		print(f'is cs clade {is_cs_clade}')
+		cssnps_arr = candidate_css[:,is_cs_clade]
+		print(np.count_nonzero(cssnps_arr))
+		clade_names = candidate_clade_names[is_cs_clade]
+
+		if np.sum(~is_cs_clade) > 0:
+			print(f"The following clades had fewer than {self.min_snps} specific SNPs and will be removed:")
+			for cname in candidate_clade_names[~is_cs_clade]:
+				print(f"{cname}\n")
+
+		# Trim cssnps_arr to just include positions with a csSNP
+		cssnps = cssnps_arr[np.count_nonzero(cssnps_arr,1) > 0]
+		cssnp_pos = core_pos[np.count_nonzero(cssnps_arr,1) > 0]
+
+		# =========================================================================
+		#  Report results
+		# =========================================================================
+
+		print('Classifier results:')
+		for c in range(len(clade_names)):
+			print('Clade ' + clade_names[c] + ': ' + str(np.count_nonzero(cssnps[:,c])) + ' csSNPs found')
+
+		# =========================================================================
+		#  Save classifier object
+		# =========================================================================
+
+		with gzip.open(self.__path_to_output_db, 'wb') as f:
+
+			pickle.dump({'clades':candidate_clades,
+						'clade_names':clade_names,
+						'cssnps':cssnps,
+						'cssnp_pos':cssnp_pos}, f)
+
+	def parse_outgroup(self):
+
+		if self.outgroup_str:
+
+			self.outgroup_ls = [item.strip() for item in self.outgroup_str.split(",")]
+
+			# Check that all outgroup genomes are present in candidate mutation table
+			if not np.array([genome in self.sample_names for genome in self.outgroup_ls]).all():
+				raise Exception('The following outgroup genomes are not present in the candidate mutation table: ' +
+								', '.join([genome for genome in self.outgroup_ls if genome not in self.sample_names]))
+
+			# outgroup_bool = np.in1d(self.sample_names, self.outgroup_ls)
+
+			# # Check if any outgroup genomes are not in sample_names
+			# if np.sum(outgroup_bool) < len(self.outgroup_ls):
+			#     print('Warning: The following outgroup genomes could not be found in the candidate mutation table. Will proceed anyway. ' +
+			#           '\n'.join([genome for genome in self.outgroup_ls if genome not in self.sample_names]))
+
+			# if np.sum(outgroup_bool) == 0:
+			#     raise Exception('None of the outgroup genomes given are present!')
+
+		else:
+			self.outgroup_ls = []
 
 
-        return clades, np.array(clade_name), new_tree
-    
-    @staticmethod
-    def write_cladeIDs(clades, output_file):
-        '''
-        Write clade_IDs file as .tsv
-        '''
-        
-        with open(output_file, 'w') as f:
-            for clade_name, tips in zip(clades.keys(), clades.values()):
-                for tip in tips:
-                    f.write(f"{tip}\t{clade_name}\n")
-    
-    def write_tree(self, tree):
-        '''
-        Write called tree to newick format
-        '''
-        with open(self.__path_to_out_tree,'w') as f:
-            f.write(tree.write(format=1)) #1 includes node names
+	def define_outgroup(self):
 
-    @staticmethod
-    def rphylip(sample_names):
-        '''Change : to | for consistency with phylip format'''
-        
-        rename = [sam.replace(':','|') for sam in sample_names]
-        
-        return np.array(rename)    
+		self.parse_outgroup()
 
-        
+		# Define outgroup
+		outgroup_bool = np.isin(self.sample_names, self.outgroup_ls)
+
+		if np.sum(outgroup_bool) == 0:
+			self.ingroup = self.maNT
+			self.ingroup_sample_names = self.sample_names
+			self.outgroup = np.array([])
+			self.outgroup_sample_names = np.array([])
+
+		else:
+			self.ingroup = self.maNT[:,~outgroup_bool]
+			self.ingroup_sample_names = self.sample_names[~outgroup_bool]
+			self.outgroup = self.maNT[:,outgroup_bool]
+			self.outgroup_sample_names = self.sample_names[outgroup_bool]
+
+
+	def call_clades_check(self):
+		'''
+		Check that the parameters passed to call_clades make sense
+		'''
+
+		dists = []
+		for node in self.tree.traverse("preorder"):
+			dists.append(node.dist)
+
+		if self.min_branch_len > max(dists):
+			raise IOError(f'Minimum branch length threshold ({self.min_branch_len}) is longer than the longest branch in the tree!')
+
+		if len(self.tree.get_leaf_names()) < self.min_nsamples*2:
+			raise IOError(f"There are fewer than {self.min_nsamples} samples in the tree. It will not be possible to call more than one clade (Minimum number of samples in a clade is {self.min_nsamples}).")
+
+
+	def call_clades(self):
+		'''
+		Call candidate clades for every branch of tree passing thresholds.
+		'''
+
+		# Initialize outputs
+		good_nodes=[] # candidate clades
+		clade_name=[] # name of candidate clade
+		tips_sets=[]; tips_ls=[] # isolates defining clades
+
+		#Go through nodes
+		for node in self.tree.traverse("preorder"):
+
+			# Cut clades at long enough branch lengths and bootstrap values
+			if node.is_leaf() is False and node.dist is not None \
+				and node.dist >= self.min_branch_len \
+				and len(node.get_leaves()) >= self.min_nsamples \
+				and node.support >= self.min_support:
+
+
+				good_nodes.append(node) # Save node object
+
+				clade_name.append('tmp') # Create temp. name for naming function
+
+				leaf_names = []
+				for leaf in node.iter_leaves():
+					leaf_names.append(leaf.name)
+
+				tips_sets.append(set(leaf_names)) # Save tip names as a set
+
+				tips_ls.append(leaf_names)
+
+		def fill_clade_names(parent, parent_name):
+			'''
+			Name daughter clades iteratively according to their parent
+			and create tree object reflecting structure.
+
+			Naming follows this logic:
+			1. Starting at the root, find the first daughter node (dnode) for
+			which dnode is a subset of the parent and only the parent
+			(i.e an immediate descendant)
+			2. Name it with 'parent_name'.1
+			3. Recur onto dnode (first daughter of 'parent'.1 will be 'parent'.1.1)
+			4. Then increase number (1->2)
+			5. Find the next dnode for which dnode is a subset of the parent
+			and only the parent. (i.e. sister to 'parent_name'.1). These will
+			thus be named 'parent'.2, 'parent'.3, etc.
+			6. Continue until all names are filled
+
+			'''
+			number=1
+			# Iterate through goodnodes
+			for i in range(len(tips_sets)):
+
+				# Is this goodnode a subset of the parent and only the parent?
+				if tips_sets[i].issubset(parent) \
+					and sum([tips_sets[i].issubset(tips_sets[c]) for c in range(len(tips_sets)) if clade_name[c] == 'tmp']) == 1:
+					#^ugly
+
+					# Name it the parent name + number
+					clade_name[i] = parent_name + '.' + str(number)
+					# Then, recur onto this node
+					fill_clade_names(tips_sets[i], clade_name[i])
+					# Then increase number
+					number = number+1
+
+		# Begin at the root
+		fill_clade_names(set(self.tree.get_leaf_names()), 'C')
+
+		#### Create ete3 graph structure from clade names ####
+		# Note that this is NOT a binary tree and can have multifurcations + internal nodes
+		# graph = ete3.Tree()
+		# for name in clade_name:
+		#     # If clade is a direct descendant from root
+		#     if name.rsplit('.', 1)[0] == 'C':
+		#         # Add clade as child of root
+		#         graph.add_child(name=name)
+		#     # If there is another ancestor
+		#     else:
+		#         # Search for the ancestor and add clade as a child of that
+		#         graph.search_nodes(name=name.rsplit('.', 1)[0])[0].add_child(name=name)
+
+
+		# Make clades dict object
+		clades = {}
+		for name, tips in zip(clade_name, tips_ls):
+			clades[name] = tips
+
+		# Annotate phylogenetic tree with updated clade names
+		new_tree = self.tree.copy()
+		for new_node in new_tree.traverse('preorder'):
+			if not new_node.is_leaf():
+				new_node_tips = new_node.get_leaf_names()
+				#Do tips of this node match good_nodes?
+				if new_node_tips in tips_ls:
+					# print("match")
+					new_node.name = clade_name[tips_ls.index(new_node_tips)]
+				else:
+					new_node.name=None
+
+
+		return clades, np.array(clade_name), new_tree
+
+	@staticmethod
+	def write_cladeIDs(clades, output_file):
+		'''
+		Write clade_IDs file as .tsv
+		'''
+
+		with open(output_file, 'w') as f:
+			for clade_name, tips in zip(clades.keys(), clades.values()):
+				for tip in tips:
+					f.write(f"{tip}\t{clade_name}\n")
+
+	def write_tree(self, tree):
+		'''
+		Write called tree to newick format
+		'''
+		with open(self.__path_to_out_tree,'w') as f:
+			f.write(tree.write(format=1)) #1 includes node names
+
+	@staticmethod
+	def rphylip(sample_names):
+		'''Change : to | for consistency with phylip format'''
+
+		rename = [sam.replace(':','|') for sam in sample_names]
+
+		return np.array(rename)
+
+
 def unanimous_to_clade(calls, sample_names, candidate_clades, clade_names, n, max_frac_ambiguous):
-    '''For a list of clades defined by their daughter genomes, return all alleles
-    along genomes that are unanimous to members of an individual clade. Clades can
-    be ancestors/children of each other.
-    
-    Args:
-        calls (arr): Array of major allele NT for each isolate (p x s) NATCG=01234.
-        sample_names (arr): Array of sample names.\n
-        candidate_clades (dict): Dictionary of genomes belonging to each clade.\n
-        clade_names (list): List of clade names.\n
-        n (float): % Ns within clade tolerated to be a csSNP (default 0.1).\n
-        core (float): Minimum shared across samples to be a csSNP (default 0.9).\n
+	'''For a list of clades defined by their daughter genomes, return all alleles
+	along genomes that are unanimous to members of an individual clade. Clades can
+	be ancestors/children of each other.
 
-    Returns:
-        unanimous_alleles (arr): pxc array listing unanimous alleles to an
-        individual clade (0 if no allele is unanimous).
+	Args:
+		calls (arr): Array of major allele NT for each isolate (p x s) NATCG=01234.
+		sample_names (arr): Array of sample names.\n
+		candidate_clades (dict): Dictionary of genomes belonging to each clade.\n
+		clade_names (list): List of clade names.\n
+		n (float): % Ns within clade tolerated to be a csSNP (default 0.1).\n
+		core (float): Minimum shared across samples to be a csSNP (default 0.9).\n
 
-    '''
-    
-    # Filter for only core genome
-    # is_core_genome = np.count_nonzero(maNT, axis=1)/len(maNT[1]) >= core
-    # core_genome = maNT[is_core_genome]
-    
-    #Initialize output array (pxc)
-    unanimous_alleles = np.zeros([len(calls),len(clade_names)])
-    
-    for i, cname in enumerate(clade_names):
-    
-        if not np.array([genome in sample_names for genome in candidate_clades[cname]]).all():
-            raise Exception(f'Genomes in Clade: {cname} not found in candidate mutation table!')
+	Returns:
+		unanimous_alleles (arr): pxc array listing unanimous alleles to an
+		individual clade (0 if no allele is unanimous).
 
-        #Get indices of genomes on maNT object        
-        clade_idx = [np.where(sample_names==name)[0][0] for name in candidate_clades[cname]]
-        
-        #maNT matrix containing just genomes belonging to this clade
-        clade_calls = calls[:,clade_idx] 
+	'''
 
-        # Mask samples with too many ambiguous allele calls
-        mask_fracNs = ( ((clade_calls>0).sum(axis=0)/len(clade_calls)) >= max_frac_ambiguous )
-        if np.sum(mask_fracNs) < 2:
-            raise Warning(f"After filtering, Clade {cname} does not have enough genomes to call unanimous alleles!")
-        
-        clade_calls_masked = clade_calls[:,mask_fracNs]
+	# Filter for only core genome
+	# is_core_genome = np.count_nonzero(maNT, axis=1)/len(maNT[1]) >= core
+	# core_genome = maNT[is_core_genome]
 
-        # Pick unanimous alleles
-        # Boolean - which ps are above n threshold   
-        n_tol = (np.count_nonzero(clade_calls_masked,axis=1) / clade_calls_masked.shape[1]) >= 1-n
-        
-        # append a column of ns (0) to every position
-        clade_samples_n = np.append(clade_calls_masked, np.zeros((len(calls),1)), axis=1)
-        # Count number of unique values in each row. 
-        # Good ps have 2 unique values: the unanimous allele and N.
-        is_unanimous = np.count_nonzero(np.diff(np.sort(clade_samples_n)), axis=1)+1 == 2
-        
-        # Write to output array
-        unanimous_alleles[:,i] = (n_tol & is_unanimous) * np.max(clade_calls_masked,axis=1)
-        
-        if np.count_nonzero((n_tol & is_unanimous) * np.max(clade_calls_masked,axis=1)) == 0:
-            
-            raise Warning(f"Clade {cname} does not have any unanimous alleles!")
-            
-    return unanimous_alleles
+	#Initialize output array (pxc)
+	unanimous_alleles = np.zeros([len(calls),len(clade_names)])
+
+	for i, cname in enumerate(clade_names):
+
+		# Restrict clade members to genomes still present after outgroup/quality filtering.
+		clade_members = [genome for genome in candidate_clades[cname] if genome in sample_names]
+
+		if len(clade_members) == 0:
+			warnings.warn(f"Clade {cname} has no genomes remaining after filtering; skipping.")
+			continue
+
+		#Get indices of genomes on maNT object
+		clade_idx = [np.where(sample_names==name)[0][0] for name in clade_members]
+
+		#maNT matrix containing just genomes belonging to this clade
+		clade_calls = calls[:,clade_idx]
+
+		# Mask samples with too many ambiguous allele calls
+		#JSB: fixed incorrect logic. old lines:
+		# mask_fracNs = ( ((clade_calls>0).sum(axis=0)/len(clade_calls)) >= max_frac_ambiguous )
+		# if np.sum(mask_fracNs) < 2:
+		# 	raise Warning(f"After filtering, Clade {cname} does not have enough genomes to call unanimous alleles!")
+
+		# clade_calls_masked = clade_calls[:,mask_fracNs]
+		#JSB: new lines:
+		# Compute ambiguous fraction per genome
+		fracNs = (clade_calls == 0).sum(axis=0) / clade_calls.shape[0]
+		# here, boolean mask_fracNs is true where sample is good i.e. does not meet ambiguity threshhold
+		mask_fracNs = fracNs <= max_frac_ambiguous
+
+		# If no genomes remain, warn and skip
+		if np.count_nonzero(mask_fracNs) < 1:
+			warnings.warn(f"After filtering, Clade {cname} does not have enough genomes to call unanimous alleles.")
+			unanimous_alleles[:, i] = 0
+			continue
+
+		clade_calls_masked = clade_calls[:, mask_fracNs]
+
+		# Pick unanimous alleles
+		# Boolean - which ps are above n threshold
+		n_tol = (np.count_nonzero(clade_calls_masked,axis=1) / clade_calls_masked.shape[1]) >= 1-n
+
+		# append a column of ns (0) to every position
+		clade_samples_n = np.append(clade_calls_masked, np.zeros((len(calls),1)), axis=1)
+		# Count number of unique values in each row.
+		# Good ps have 2 unique values: the unanimous allele and N.
+		is_unanimous = np.count_nonzero(np.diff(np.sort(clade_samples_n)), axis=1)+1 == 2
+
+		# Write to output array
+		unanimous_alleles[:,i] = (n_tol & is_unanimous) * np.max(clade_calls_masked,axis=1)
+
+		if np.count_nonzero((n_tol & is_unanimous) * np.max(clade_calls_masked,axis=1)) == 0:
+
+			raise Warning(f"Clade {cname} does not have any unanimous alleles!")
+
+	return unanimous_alleles
 
 def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, clade_names):
     '''Search for unique alleles among the unanimous alleles for a particular clade.
-    Search occurs only against clades that aren't direct descendants of the target
-    clade, nor direct ancestors on the path to the root, plus against any genomes 
-    not belonging to any clade.
-
+    
     Args:
-        maNT (arr): Array of major allele NT for each isolate (p x s) NATCG=01234.
-                    Note that this function will not do any filtering across positions\n.
-        unanimous_alleles (arr): pxc array listing unanimous alleles to an
-        individual clade (0 if no allele is unanimous).\n
-        sample_names (arr): Array of sample names.\n
-        candidate_clades (dict): Dictionary of genomes belonging to each clade.\n
-        clade_names (list): List of clade names.\n
+        maNT (arr): Array of major allele NT for each isolate (p x s).
+        unanimous_alleles (arr): pxc array listing unanimous alleles.
+        sample_names (arr): Array of sample names.
+        candidate_clades (dict): Dictionary of genomes belonging to each clade.
+        clade_names (list): List of clade names.
 
     Returns:
-        css_mat (arr): DESCRIPTION.
-
+        css_mat (arr): Matrix of unique alleles.
     '''
-            
-    # Initialize output array
-    css_mat = np.zeros((len(unanimous_alleles),len(clade_names)))
     
-    # First exclude unclassified 
-    cl = []
-    for key, val in candidate_clades.items():
-        cl = cl + val
-    uncl_bool = np.in1d( sample_names,
-                         cl)
+    # Initialize output array
+    css_mat = np.zeros((len(unanimous_alleles), len(clade_names)))
+    
+    # Pre-convert sample_names to a list for safe comparison
+    sample_names_list = list(sample_names)
     
     for c, cname in enumerate(clade_names):
         
-        #Genomes to compare this clade against for uniqueness
+        # 1. Identify indices of the current clade members
+        # Using set intersection is safer than numpy string matching
+        clade_member_set = set(candidate_clades[cname])
         
-        cp_bool = ~np.in1d( sample_names,
-                            np.array(candidate_clades[cname]) ) & uncl_bool
-                    
-        # cp_bool = ~np.in1d( clade_names, np.unique(np.array(ancdesc)) )
+        # Create a boolean mask: True if sample is NOT in the current clade
+        # This defines the "background" against which we check for uniqueness
+        cp_bool = np.array([s not in clade_member_set for s in sample_names_list])
         
-        # Get alleles unique to this clade
-        this_clade_alleles = unanimous_alleles[:,c]
-        is_unique = np.sum( np.expand_dims(this_clade_alleles,1) == maNT[:,cp_bool]
-                           ,axis=1) == 0
+        # DIAGNOSTIC PRINT: Check if we are accidentally comparing against ourselves
+        # If cp_bool is True for everyone, we have a problem.
+        # The count of False values should equal the number of samples in the clade.
+        clade_size = len(candidate_clades[cname])
+        excluded_count = np.count_nonzero(~cp_bool)
         
+        if excluded_count != clade_size:
+            print(f"WARNING: Clade '{cname}' has {clade_size} members, but {excluded_count} were excluded from background.")
+            print(f"This implies {clade_size - excluded_count} members are being treated as background (Self-Comparison).")
+        
+        # 2. Get alleles unique to this clade
+        this_clade_alleles = unanimous_alleles[:, c]
+        
+        # Compare against the background (maNT[:, cp_bool])
+        # We look for rows where the clade allele equals ANY allele in the background
+        # Sum > 0 means it matched something in the background (not unique)
+        background_alleles = maNT[:, cp_bool]
+        
+        if background_alleles.shape[1] > 0:
+            is_unique = np.sum(np.expand_dims(this_clade_alleles, 1) == background_alleles, axis=1) == 0
+        else:
+            # If there is no background (e.g. only 1 clade total), everything is unique
+            is_unique = np.ones(len(this_clade_alleles), dtype=bool)
+
+        # 3. Filter and store
         this_clade_alleles[~is_unique] = 0
-        css_mat[:,c] = this_clade_alleles
-        # print(f"{cname}: {np.count_nonzero(css_mat[:,c])} csSNPs")
-    
+        css_mat[:, c] = this_clade_alleles
+
+        # print(f"{cname}: {np.count_nonzero(css_mat[:, c])} csSNPs found")
+
     return css_mat
 
 
@@ -529,7 +591,7 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #     '''
 #     Main controller of the Tree step.
 #     '''
-    
+
 #     def __init__(self, path_to_nwk_file,
 #                  path_to_out_tree,
 #                  path_to_out_cladeIDs,
@@ -538,33 +600,33 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #                  min_support=0.75,
 #                  path_to_cmt_file=False,
 #                  rescale=False):
-        
+
 #         self.__path_to_out_cladeIDs = path_to_out_cladeIDs
 #         self.__path_to_out_tree = path_to_out_tree
-        
+
 #         self.min_branch_len = min_branch_len
 #         self.min_nsamples = min_nsamples
 #         self.min_support = min_support
-        
+
 #         self.rescale_bool = rescale
-        
+
 #         if min_support > 1 or min_support < 0:
 #             raise IOError('Branch support threshold must be between 0 and 1!')
-        
+
 #         if rescale:
 #             if not path_to_cmt_file:
 #                 raise IOError('Rescaling a tree requires a candidate mutation table!')
-                
+
 #     def main(self):
-        
+
 #         print("Calling clades...")
 
 #         clades, clade_names, clade_tips, called_tree = self.clade_caller()
-        
+
 #         self.clade_names = clade_names
 #         self.clade_tips = clade_tips
 #         self.called_tree = called_tree
-    
+
 #         # Do the writing in the controller
 #         # print("Writing...")
 #         # self.write_cladeIDs()
@@ -575,73 +637,73 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #         '''
 #         Call candidate clades for every branch of tree passing thresholds.
 #         '''
-        
+
 #         # Initialize outputs
 #         good_nodes=[] # candidate clades
 #         clade_name=[] # name of candidate clade
 #         tips_sets=[]; tips_ls=[] # isolates defining clades
-        
-#         #Go through nodes 
+
+#         #Go through nodes
 #         for node in self.tree.traverse("preorder"):
-            
+
 #             # Cut clades at long enough branch lengths and bootstrap values
 #             if node.is_leaf() is False and node.dist is not None \
 #                 and node.dist >= self.min_branch_len \
 #                 and len(node.get_leaves()) >= self.min_nsamples \
 #                 and node.support >= self.min_support:
-                
-                
+
+
 #                 good_nodes.append(node) # Save node object
-                
+
 #                 clade_name.append('tmp') # Create temp. name for naming function
-                
+
 #                 leaf_names = []
 #                 for leaf in node.iter_leaves():
 #                     leaf_names.append(leaf.name)
-                
+
 #                 tips_sets.append(set(leaf_names)) # Save tip names as a set
-                
+
 #                 tips_ls.append(leaf_names)
 
 #         def fill_clade_names(parent, parent_name):
 #             '''
-#             Name daughter clades iteratively according to their parent 
+#             Name daughter clades iteratively according to their parent
 #             and create tree object reflecting structure.
-            
+
 #             Naming follows this logic:
-#             1. Starting at the root, find the first daughter node (dnode) for 
-#             which dnode is a subset of the parent and only the parent 
+#             1. Starting at the root, find the first daughter node (dnode) for
+#             which dnode is a subset of the parent and only the parent
 #             (i.e an immediate descendant)
 #             2. Name it with 'parent_name'.1
 #             3. Recur onto dnode (first daughter of 'parent'.1 will be 'parent'.1.1)
 #             4. Then increase number (1->2)
-#             5. Find the next dnode for which dnode is a subset of the parent 
-#             and only the parent. (i.e. sister to 'parent_name'.1). These will 
+#             5. Find the next dnode for which dnode is a subset of the parent
+#             and only the parent. (i.e. sister to 'parent_name'.1). These will
 #             thus be named 'parent'.2, 'parent'.3, etc.
 #             6. Continue until all names are filled
-                
+
 #             '''
 #             number=1
 #             # Iterate through goodnodes
 #             for i in range(len(tips_sets)):
-                
+
 #                 # Is this goodnode a subset of the parent and only the parent?
 #                 if tips_sets[i].issubset(parent) \
-#                     and sum([tips_sets[i].issubset(tips_sets[c]) for c in range(len(tips_sets)) if clade_name[c] == 'tmp']) == 1: 
+#                     and sum([tips_sets[i].issubset(tips_sets[c]) for c in range(len(tips_sets)) if clade_name[c] == 'tmp']) == 1:
 #                     #^ugly
-                        
+
 #                     # Name it the parent name + number
 #                     clade_name[i] = parent_name + '.' + str(number)
 #                     # Then, recur onto this node
 #                     fill_clade_names(tips_sets[i], clade_name[i])
 #                     # Then increase number
 #                     number = number+1
-                
+
 #         # Begin at the root
 #         fill_clade_names(set(self.tree.get_leaf_names()), 'C')
-        
+
 #         #### Create ete3 graph structure from clade names ####
-#         # Note that this is NOT a binary tree and can have multifurcations + internal nodes    
+#         # Note that this is NOT a binary tree and can have multifurcations + internal nodes
 #         clades = ete3.Tree()
 #         for name in clade_name:
 #             # If clade is a direct descendant from root
@@ -652,8 +714,8 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #             else:
 #                 # Search for the ancestor and add clade as a child of that
 #                 clades.search_nodes(name=name.rsplit('.', 1)[0])[0].add_child(name=name)
-    
-    
+
+
 #         #### Annotate phylogenetic tree with updated clade names ####
 #         new_tree = self.tree.copy()
 #         for new_node in new_tree.traverse('preorder'):
@@ -665,20 +727,20 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #                     new_node.name = clade_name[tips_ls.index(new_node_tips)]
 #                 else:
 #                     new_node.name=None
-                    
-                    
+
+
 #         return clades, np.array(clade_name), tips_ls, new_tree
-            
+
 #     def write_cladeIDs(self):
 #         '''
 #         Write clade_IDs file as .tsv
 #         '''
-        
+
 #         with open(self.__path_to_out_cladeIDs, 'w') as f:
 #             for name, tips in zip(self.clade_names, self.clade_tips):
 #                 for tip in tips:
 #                     f.write(f"{tip}\t{name}\n")
-    
+
 #     def write_tree(self, tree):
 #         '''
 #         Write called tree to newick format
@@ -689,64 +751,64 @@ def unique_to_clade(maNT, unanimous_alleles, sample_names, candidate_clades, cla
 #     @staticmethod
 #     def rphylip(sample_names):
 #         '''Change : to | for consistency with phylip format'''
-        
+
 #         rename = [sam.replace(':','|') for sam in sample_names]
-        
-#         return np.array(rename)    
-    
 
-def map_4_repisolates(path_to_candidate_clades, 
-                      path_to_cluster_IDs):
-    '''
-    If tree is built off representative isolates, map clades defined on tree
-    onto larger isolate collection.
-    '''
+#         return np.array(rename)
 
-    cand_clades, cand_clade_names = helper.read_clades_file(path_to_candidate_clades,
-                                                            uncl_marker='-1')
-    
-    return
-    
-def rename_phylip(phylip2names_file, intree, outtree, 
-                  outclustertree=False, rep_CMT_file=False):
-    '''Given a renaming file, rename 10chr phylip names into long format
 
-    Args:
-        phylip2names_file (TYPE): DESCRIPTION.
-        intree (TYPE): DESCRIPTION.
-        outtree (TYPE): DESCRIPTION.
+def map_4_repisolates(path_to_candidate_clades,
+					  path_to_cluster_IDs):
+	'''
+	If tree is built off representative isolates, map clades defined on tree
+	onto larger isolate collection.
+	'''
 
-    Returns:
-        None.
+	cand_clades, cand_clade_names = helper.read_clades_file(path_to_candidate_clades,
+															uncl_marker='-1')
 
-    '''
-    # Get phylip2names as dict
-    phylip2names=dict()
-    with open(phylip2names_file) as f:
-        for line in f:
-            key, value = line.strip().split('\t')
-            phylip2names[key] = value
-            
-    # Replace phylip tree names
-    with open(intree) as f:
-        nwk=f.read()
-    #Replace with representative isolate name
-    for i in phylip2names.keys():
-        nwk=nwk.replace(i,phylip2names[i])
-    with open(outtree,'w') as f:
-        f.write(nwk)
-    
-    if outclustertree: # Optionally output tree named by cluster
-    
-        # Get which tree isolate belongs to which cluster
-        with gzip.open(rep_CMT_file,'rb') as f:
-            CMT=pickle.load(f); sample_names=CMT[0]; cluster_IDs=CMT[4]
-        tree2cluster=dict()
-        for sam,clu in zip(sample_names,cluster_IDs):
-            tree2cluster[sam]=clu
-            
-        #Replace with cluster name
-        for i in tree2cluster.keys():
-            nwk=nwk.replace(i,'Cluster '+tree2cluster[i])
-        with open(outclustertree,'w') as f:
-            f.write(nwk)
+	return
+
+def rename_phylip(phylip2names_file, intree, outtree,
+				  outclustertree=False, rep_CMT_file=False):
+	'''Given a renaming file, rename 10chr phylip names into long format
+
+	Args:
+		phylip2names_file (TYPE): DESCRIPTION.
+		intree (TYPE): DESCRIPTION.
+		outtree (TYPE): DESCRIPTION.
+
+	Returns:
+		None.
+
+	'''
+	# Get phylip2names as dict
+	phylip2names=dict()
+	with open(phylip2names_file) as f:
+		for line in f:
+			key, value = line.strip().split('\t')
+			phylip2names[key] = value
+
+	# Replace phylip tree names
+	with open(intree) as f:
+		nwk=f.read()
+	#Replace with representative isolate name
+	for i in phylip2names.keys():
+		nwk=nwk.replace(i,phylip2names[i])
+	with open(outtree,'w') as f:
+		f.write(nwk)
+
+	if outclustertree: # Optionally output tree named by cluster
+
+		# Get which tree isolate belongs to which cluster
+		with gzip.open(rep_CMT_file,'rb') as f:
+			CMT=pickle.load(f); sample_names=CMT[0]; cluster_IDs=CMT[4]
+		tree2cluster=dict()
+		for sam,clu in zip(sample_names,cluster_IDs):
+			tree2cluster[sam]=clu
+
+		#Replace with cluster name
+		for i in tree2cluster.keys():
+			nwk=nwk.replace(i,'Cluster '+tree2cluster[i])
+		with open(outclustertree,'w') as f:
+			f.write(nwk)

--- a/phlame/plot.py
+++ b/phlame/plot.py
@@ -31,51 +31,51 @@ class PlotSample():
                  max_pi = 0.35,
                  min_prob = 0.5):
 
-        
+
         self.path_to_frequencies_file = path_to_frequencies_file
         self.path_to_data_file = path_to_data_file
         self.path_to_output_plot = path_to_output_plot
         self.hfont = {'fontname':'Helvetica',
                             'fontsize':12}
-        
+
         self.max_pi = max_pi
         self.min_prob = min_prob
 
         if not self.path_to_output_plot.endswith('.pdf'):
             self.path_to_output_plot += '.pdf'
 
-        
+
     def main(self):
 
         sample_name = os.path.basename(self.path_to_frequencies_file)
 
-        fig = self.plot_sample(sample_name, 
+        fig = self.plot_sample(sample_name,
                                self.path_to_frequencies_file,
                                self.path_to_data_file,
                                max_pi = self.max_pi,
                                min_prob = self.min_prob)
-        
+
         fig.tight_layout()
 
         fig.savefig(self.path_to_output_plot, format='pdf')
 
-  
-    def plot_sample(self, sample_name, 
+
+    def plot_sample(self, sample_name,
                     path_to_frequencies_file,
                     path_to_data_file,
                     max_pi, min_prob):
         '''
         Plot all classify information for a single sample.
         '''
-        
-        # Load in sample 
+
+        # Load in sample
         sample_frequencies = helper.Frequencies(path_to_frequencies_file)
         data = helper.FrequenciesData(path_to_data_file)
-        
+
         # Pick which clades to model
         model_bool = (np.logical_or.reduce((data.counts_MLE != -1),1))
         # model_bool = np.in1d(sample_frequencies.freqs.index , [36, 83])
-        
+
         counts_tmp = []
         total_tmp = []
         clade_names = []
@@ -83,50 +83,53 @@ class PlotSample():
         # ========================================================================
         #  Organize information by clade
         # ========================================================================
-        
+
         for i in range(len(data.clade_counts)):
-            
+
             # Ignore clades with not enough counts to be modeled
             if not model_bool[i]:
                 continue
-            
-            counts_tmp.append( data.clade_counts[i][0] + 
+
+            counts_tmp.append( data.clade_counts[i][0] +
                                 data.clade_counts[i][1] )
-            
-            total_tmp.append( data.clade_counts[i][2] + 
+
+            total_tmp.append( data.clade_counts[i][2] +
                                 data.clade_counts[i][3] )
-            
+
             clade_names.append( sample_frequencies.freqs.index[i] )
 
             total_lambda.append( data.total_MLE[i][0] )
-                
+
 
         # ========================================================================
         #  Plot stuff
         # ========================================================================
-        
+
         nplots = np.sum(model_bool)
 
         if nplots < 2:
             nplots = 2 # Quick fix
         fig, axs = plt.subplots(nplots,4)
         fig.set_size_inches(12, (nplots*2)+2)
-        
+
         # Iterate through clades
         self.mle_flag = False
         for c, clade in enumerate(clade_names):
-            
-            # Plot counts histogram
+
             axs[c,0].set_title(f"{clade}")
-            axs[c,0].hist(counts_tmp[c], 
-                        bins=np.arange(0,max(counts_tmp[c])+2,1),
-                        color='r', alpha=0.5) # csSNP counts
-            axs[c,0].hist(total_tmp[c], 
-                        bins=np.arange(0,max(total_tmp[c])+2,1),
-                        color='k', alpha=0.5) # Total counts
+
+            # Compute shared bins based on one dataset (or both combined)
+            data_min = min(np.min(counts_tmp[c]), np.min(total_tmp[c]))
+            data_max = max(np.max(counts_tmp[c]), np.max(total_tmp[c]))
+            bins = np.linspace(data_min, data_max, 11)   # 10 bins → 11 edges
+
+            # Plot both histograms with the same bin edges
+            axs[c,0].hist(counts_tmp[c], bins=bins, color='r', alpha=0.5, label='counts')
+            axs[c,0].hist(total_tmp[c],  bins=bins, color='k', alpha=0.5, label='total')
+
             axs[c,0].set_xlabel('Counts', **self.hfont)
             axs[c,0].set_ylabel('# of SNVs', **self.hfont)
-            axs[c,0].tick_params('both', **{'labelsize':12})
+            axs[c,0].tick_params('both', labelsize=12)
 
             if data.mode=='mle':
                 if not self.mle_flag:
@@ -143,67 +146,67 @@ class PlotSample():
             pi_bins = np.histogram(pi_chain,
                                     np.arange(0,1.01,0.01),
                                     density=True)
-            lambda_bins = np.histogram(lambda_chain, 
+            lambda_bins = np.histogram(lambda_chain,
                                         bins=100,
                                         density=True)
             freq_bins = np.histogram(lambda_chain/data.total_MLE[model_bool][c][0],
                                      np.arange(0,1.01,0.01),
                                      density=True)
-            
-            
-            
+
+
+
             # Calc prob that chain < max_pi
             prob = np.sum(np.array(data.chain)[model_bool][c]['pi']<max_pi)/nchain
-            
+
             # Calc HPD
             hpd = self.get_hpd(np.array(data.chain)[model_bool][c]['pi'], 0.95)
 
             # Report the output frequency
-            
+
             if prob > min_prob:
                 frequency = sample_frequencies.freqs.loc[clade].values[0]
                 freq_color='g'
             else:
                 frequency = 0
                 freq_color='k'
-                
-            axs[c,0].text(0.95, 0.95, 
-            f"Frequency: {frequency:.2f}", 
+
+            axs[c,0].text(0.95, 0.95,
+            f"Frequency: {frequency:.2f}",
             ha='right', va='top',
             transform=axs[c,0].transAxes,**{'fontsize':8, 'color':freq_color})
 
             # pi posterior
-            axs[c,1].plot(pi_bins[1][:-1], 
-                        pi_bins[0],  
+            axs[c,1].plot(pi_bins[1][:-1],
+                        pi_bins[0],
                         color='g', label='Posterior dist.')
-            axs[c,1].text(0.99, 0.8, 
-                        f"P(pi<{max_pi})={prob:.2f}", 
-                        ha='right', va='bottom', 
+            axs[c,1].text(0.99, 0.8,
+                        f"P(pi<{max_pi})={prob:.2f}",
+                        ha='right', va='bottom',
                         transform=axs[c,1].transAxes,**self.hfont)
             axs[c,1].axvline(max_pi, color='k', ls='--', label='max_pi')
             axs[c,1].set_xlabel('pi',**self.hfont); axs[c,1].set_ylabel('Density',**self.hfont)
             axs[c,1].set_xlim(0,1)
-            axs[c,1].plot( hpd, [0.1,0.1], color='k', 
+            axs[c,1].plot( hpd, [0.1,0.1], color='k',
                         alpha=0.5, linewidth=4, label='HPD')
             # axs[c,1].legend()
-    
+
             # lambda posterior
             axs[c,2].plot(lambda_bins[1][:-1],
-                            lambda_bins[0], 
+                            lambda_bins[0],
                             color='b', label='MCMC')
             axs[c,2].set_xlabel('lambda',**self.hfont); axs[c,2].set_ylabel('Density',**self.hfont)
             # axs[c,2].legend()
 
             # alpha posterior
             axs[c,3].plot(freq_bins[1][:-1],
-                          freq_bins[0], 
+                          freq_bins[0],
                           color='b', label='MCMC')
             axs[c,3].set_xlabel('Estimated frequency',**self.hfont); axs[c,3].set_ylabel('Density',**self.hfont)
-            
-            # Also plot the prior 
-                    
+
+            # Also plot the prior
+
         return fig
-    
+
     @staticmethod
     def get_hpd(chain, interval_size=0.95):
         """
@@ -214,16 +217,16 @@ class PlotSample():
 
         # Number of total samples taken
         n = len(chain)
-        
+
         # Get interval size that should be included in HPD
         interval = np.floor(interval_size * n).astype(int)
-        
-        # Get width (in units of param) of all intervals 
+
+        # Get width (in units of param) of all intervals
         int_width = d[interval:] - d[:n-interval]
-        
+
         # Pick out minimal interval
         min_int = np.argmin(int_width)
-        
+
         # Return interval
         return np.array([d[min_int], d[min_int+interval]])
 
@@ -232,18 +235,18 @@ def csSNP_vs_branchlen(tree, csSNPs, clade_names, label):
 
     names_to_exclude = np.array(['C.1','C.2'])
     exclude_bool = ~np.in1d(clade_names, names_to_exclude)
-   
+
     num_csSNPs = np.zeros(len(clade_names[exclude_bool]))
     branch_lens = np.zeros(len(clade_names[exclude_bool]))
 
     for i, name in enumerate(clade_names[exclude_bool]):
-        
+
         num_csSNPs[i] = np.count_nonzero(csSNPs[:,exclude_bool][:,i])
         branch_lens[i] = tree.search_nodes(name=name)[0].dist
-    
+
     # branch_lens_sort = np.sort(branch_lens)
-    # 
-    
+    #
+
     plt.scatter(branch_lens, num_csSNPs, label=label, alpha=.5)
     plt.plot([0,np.max(branch_lens)],[0,np.max(branch_lens)/10],color='k')
     # plt.yscale('log'); plt.xscale('log')
@@ -253,55 +256,55 @@ def csSNP_vs_branchlen(tree, csSNPs, clade_names, label):
     plt.ylim(0,np.max(num_csSNPs)+100)
 
     # fig.show()
-    
+
     return
 
-def nisos_vs_dist_from_tips(tree, 
-                            clades, clade_names, 
+def nisos_vs_dist_from_tips(tree,
+                            clades, clade_names,
                             label):
     '''
     Iteratively include clades from tips and plot # of isolates included as a
     fxn of dist from tips.
-    '''   
-    
+    '''
+
     dist_from_tips = np.zeros(len(clade_names))
-    
+
     for i, name in enumerate(clade_names):
 
         node = tree.search_nodes(name=name)[0]
-        
+
         # Calc average distance from tips
         dist=[]
         for node_leaf in node.iter_leaves():
             dist.append(node.get_distance(node_leaf))
-        
+
         dist_from_tips[i] = np.mean(dist)
-        
-        
+
+
     dist_from_tips_sort = np.sort(dist_from_tips)
     clade_names_sort = clade_names[np.argsort(dist_from_tips)]
-    
+
     isos = []
     nisos = []
-    
+
     for clade in clade_names_sort:
-        
+
         isos = np.unique(np.append(isos,clades[clade]))
         nisos.append( len(isos) )
-        
-    plt.plot(dist_from_tips_sort, 
+
+    plt.plot(dist_from_tips_sort,
               np.array(nisos)/len(tree), label=label)
-    # plt.plot(np.arange(0, len(clade_names))/len(clade_names), 
+    # plt.plot(np.arange(0, len(clade_names))/len(clade_names),
     #           np.array(nisos)/len(tree), label=label)
 
     plt.ylabel('Percent isolates included')
     plt.xlabel('Average distance from tips (# SNPs)')
     # plt.xlabel('Nth percentile distance from tips')
-        
+
     return
 
 
-def callable_dist_from_tips(tree, 
+def callable_dist_from_tips(tree,
                             clade_names,
                             cand_clade_names,
                             lbl):
@@ -309,52 +312,52 @@ def callable_dist_from_tips(tree,
     Plot hist of all possible callable clades / clades > 10 csSNPs as a fxn of
     dist from tips
     '''
-    
+
     dist_from_tips = np.zeros(len(cand_clade_names))
-    
+
     for i, name in enumerate(cand_clade_names):
 
         node = tree.search_nodes(name=name)[0]
-        
+
         # Calc average distance from tips
         dist=[]
         for node_leaf in node.iter_leaves():
             dist.append(node.get_distance(node_leaf))
-        
+
         dist_from_tips[i] = np.mean(dist)
-    
+
     cssnps_bool = np.in1d(cand_clade_names,clade_names)
-    
-    plt.hist(dist_from_tips, 
+
+    plt.hist(dist_from_tips,
              np.logspace(np.log10(1),np.log10(np.max(dist_from_tips)), 40),
              alpha=0.5, color='k', label='candidate clades')
-    plt.hist(dist_from_tips[cssnps_bool], 
+    plt.hist(dist_from_tips[cssnps_bool],
              np.logspace(np.log10(1),np.log10(np.max(dist_from_tips)), 40),
              alpha=0.5, color='r', label='clades with csSNPs')
     plt.xscale('log')
     plt.xlabel('Average distance from tips (# SNPs)')
     plt.ylabel('Number of clades')
     plt.title(f"{lbl}:  {len(clade_names)/len(cand_clade_names):.2f} candidate clades had csSNPs")
-    
+
     return
 
 def plot_classifier(path_to_classifier):
-    
+
     with gzip.open(path_to_classifier) as f:
-        
+
         cssnp_dct = pickle.load(f)
-        
+
     clade_names = cssnp_dct['clade_names']
     cssnps = cssnp_dct['cssnps']
-    
+
     cssnp_ct = np.zeros(len(clade_names))
     for c in range(len(clade_names)):
         cssnp_ct[c] = (np.count_nonzero(cssnps[:,c]))
-        
+
     # Order decreasing
     cssnp_ct_sort = np.sort(cssnp_ct)
     clade_names_sort = clade_names[np.argsort(cssnp_ct)]
-    
+
     # =========================================================================
     #  Plot
     # =========================================================================
@@ -374,7 +377,7 @@ def plot_classifier(path_to_classifier):
 
     fig.show()
     plt.tight_layout()
-    
+
     return fig
 
 def plot_sample_coverage(coverage,
@@ -383,7 +386,7 @@ def plot_sample_coverage(coverage,
     coverage_median = np.median(coverage,axis=0)
 
     fig, axs = plt.subplots()
-    
+
     maxcov=coverage_median.max()
     maxcovbin=np.ceil(maxcov/10)*10+10
     my_bins = np.arange(0,int(maxcovbin),5)
@@ -393,43 +396,43 @@ def plot_sample_coverage(coverage,
     plt.axvline(coverage_cutoff, color='r')
     plt.ylabel('Number of samples')
     plt.title('Median coverage across samples')
-    
+
     return fig
 
 def plot_position_presence(presence_arr,
                             max_ns_cutoff,
                             filter_name):
-    
+
     fig, axs = plt.subplots()
 
     my_bins = np.linspace( np.min(presence_arr), np.max(presence_arr), 100 )
-    axs.hist(x=presence_arr, bins=my_bins, 
+    axs.hist(x=presence_arr, bins=my_bins,
             color='#0504aa', alpha=0.7, rwidth=0.85)
-    
+
     plt.grid(axis='y', alpha=0.75)
     plt.xlabel(filter_name)
     plt.ylabel('Number of positions')
     # Add a line at filter cutoff
     plt.axvline(x = max_ns_cutoff, color = 'r')
-    
+
     return fig
 
 def plot_sample_breadth(breadth_bysample_arr,
                         min_breadth_cutoff):
-    
+
     fig, axs = plt.subplots()
-    
+
     # max()
     # my_bins = np.arange(0,1,0.01)
-    
-    n, bins, patches = plt.hist(x=breadth_bysample_arr, bins=20, 
+
+    n, bins, patches = plt.hist(x=breadth_bysample_arr, bins=20,
                                 color='#0504aa', alpha=0.7, rwidth=0.85)
     plt.grid(axis='y', alpha=0.75)
     plt.xlabel('Percentage of positions with Ns per sample')
     plt.axvline(min_breadth_cutoff, color='r')
     plt.ylabel('Number of samples')
     # plt.title('Median coverage across samples')
-    
+
     return fig
 
 
@@ -446,7 +449,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 #             path_to_frequencies_file, path_to_data_file,
 #             max_pi, min_prob,
 #             nchain, nburn, seed):
-    
+
 #     sample_frequencies = Frequencies(path_to_frequencies_file)
 #     data = FrequenciesData(path_to_data_file)
 
@@ -460,21 +463,21 @@ def plot_sample_breadth(breadth_bysample_arr,
 #                                     total_counts,
 #                                     seed=seed,
 #                                     force_alpha=False)
-    
+
 #     prob, hpd = cts_fit.fit(max_pi = max_pi,
 #                        nchain = nchain,
 #                        nburn = nburn)
 
 
 #     #################################### Plot ####################################
-    
+
 #     fig, axs = plt.subplots(1,4)
-    
+
 #     # Plot counts histogram
-#     axs[0].hist(counts, 
+#     axs[0].hist(counts,
 #                 bins=np.arange(0,max(counts)+2,1),
 #                 color='r', alpha=0.5) # csSNP counts
-#     axs[0].hist(total_counts, 
+#     axs[0].hist(total_counts,
 #                 bins=np.arange(0,max(total_counts)+2,1),
 #                 color='k', alpha=0.5) # Total counts
 #     axs[0].set_xlabel('Counts', **self.hfont)
@@ -487,7 +490,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 #     pi_bins = np.histogram(np.array(cts_fit.chain['pi']),
 #                             np.arange(0,1.01,0.01),
 #                             density=True)
-#     lambda_bins = np.histogram(np.array(cts_fit.chain['a'])/np.array(cts_fit.chain['b']), 
+#     lambda_bins = np.histogram(np.array(cts_fit.chain['a'])/np.array(cts_fit.chain['b']),
 #                                 bins=100,
 #                                 density=True)
 #     alpha_bins = np.histogram(np.array(cts_fit.chain['a']),
@@ -495,23 +498,23 @@ def plot_sample_breadth(breadth_bysample_arr,
 #                                 density=True)
 
 #     # pi posterior
-#     axs[1].plot(pi_bins[1][:-1], 
-#                     pi_bins[0],  
+#     axs[1].plot(pi_bins[1][:-1],
+#                     pi_bins[0],
 #                     color='g', label='Posterior dist.')
-#     axs[1].text(0.99, 0.8, 
-#                 f"P(pi<{max_pi})={prob:.2f}", 
-#                 ha='right', va='bottom', 
+#     axs[1].text(0.99, 0.8,
+#                 f"P(pi<{max_pi})={prob:.2f}",
+#                 ha='right', va='bottom',
 #                 transform=axs[1].transAxes,**self.hfont)
 #     axs[1].axvline(max_pi, color='g', ls='--', label='max_pi')
 #     # axs[c,1].axvline(data.counts_MAP[model_bool][c][2], color='r', label='MAP')
 #     axs[1].set_xlabel('Pi',**self.hfont); axs[1].set_ylabel('Probability',**self.hfont)
 #     axs[1].set_xlim(0,1)
-#     axs[1].plot( hpd, [0.1,0.1], color='k', 
+#     axs[1].plot( hpd, [0.1,0.1], color='k',
 #                 alpha=0.5, linewidth=4, label='HPD')
 
 #     # lambda posterior
 #     axs[2].plot(lambda_bins[1][:-1],
-#                     lambda_bins[0], 
+#                     lambda_bins[0],
 #                     color='b', label='MCMC')
 #     # axs[c,2].axvline(data.counts_MLE[model_bool][c][0], color='k', label='MLE')
 #     # axs[c,2].axvline(data.counts_MAP[model_bool][c][0], color='r', label='Posterior mean')
@@ -520,7 +523,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 
 #     # alpha posterior
 #     axs[3].plot(alpha_bins[1][:-1],
-#                     alpha_bins[0], 
+#                     alpha_bins[0],
 #                     color='b', label='MCMC')
 #     # axs[c,3].axvline(data.counts_MLE[model_bool][c][1], color='k', label='MLE')
 #     # axs[c,3].axvline(data.counts_MAP[model_bool][c][1], color='r', label='Posterior mean')
@@ -531,7 +534,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 
 
 #     ################################### Plot 2 ###################################
-    
+
 #     fig, axs = plt.subplots(3)
 #     fig.set_size_inches(12, 8)
 #     # Bin MCMC chain
@@ -541,8 +544,8 @@ def plot_sample_breadth(breadth_bysample_arr,
 #     nchain = len(pi_chain)
 
 #     # Pi chain
-#     axs[0].plot(np.arange(0,nchain), 
-#                 pi_chain,  
+#     axs[0].plot(np.arange(0,nchain),
+#                 pi_chain,
 #                 color='g', label='Posterior dist.')
 #     axs[0].set_xlabel('Iteration',**self.hfont); axs[0].set_ylabel('Pi',**self.hfont)
 #     axs[0].set_ylim(0,1)
@@ -550,7 +553,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 
 #     # lambda posterior
 #     axs[1].plot(np.arange(0,nchain),
-#                 lambda_chain, 
+#                 lambda_chain,
 #                 color='b')
 #     axs[1].set_xlabel('Iteration',**self.hfont); axs[1].set_ylabel('Lambda',**self.hfont)
 #     axs[1].set_title(f"Lambda chain")
@@ -558,7 +561,7 @@ def plot_sample_breadth(breadth_bysample_arr,
 
 #     # alpha posterior
 #     axs[2].plot(np.arange(0,nchain),
-#                 alpha_chain, 
+#                 alpha_chain,
 #                 color='r')
 #     axs[2].set_xlabel('Iteration',**self.hfont); axs[2].set_ylabel('Alpha',**self.hfont)
 #     axs[2].set_title(f"Alpha chain")
@@ -575,6 +578,3 @@ def plot_sample_breadth(breadth_bysample_arr,
 # #             nchain = 10000,
 # #             nburn = 500,
 # #             seed = 12345)
-
-
-

--- a/phlame/tree.py
+++ b/phlame/tree.py
@@ -347,8 +347,7 @@ class CMT2tree():
 
         self.raxml()
 
-        self.raxml_success()
-
+        print("Tree built. Renaming phylip names...")
         self.rename_phylip()
 
         
@@ -575,32 +574,13 @@ class CMT2tree():
                         " -w " + shlex.quote(working_dir) +
                         " -n " + basename + 
                         " -m GTRCAT -p 12345 ", shell=True)
-        
-    def raxml_success(self):
-        '''
-        Check if RAxML ran successfully.
-        '''
 
-        basename = os.path.basename(self.output_tree)
-        raxml_outpath = self.output_tree.replace(basename, 
-                                                 'RAxML_bestTree.'+basename)
-
-        if not os.path.exists(raxml_outpath):
-            raise Exception("RAxML output tree file not found: " + raxml_outpath)
-        
-        else:
-            print("Tree built successfully: " + raxml_outpath)
-        
-        return True
-        
 
     def rename_phylip(self):
         '''
         Convert 10chr phylip names in a nwk file into long format.
         And get away from raxml naming system!
         '''
-
-        print("Renaming phylip names in tree...")
 
         # Read in RAxML tree
         basename = os.path.basename(self.output_tree)


### PR DESCRIPTION
- classify.py: refactored clade fitting into standalone fit_clade_worker() for parallel execution via multiprocessing/ProcessPoolExecutor
- makedb.py: added path_to_out_tree parameter (-y did not do anything in previous build); fixed some broken logic
- helper_functions.py: safer scaffold index lookup (guards missing contig), np.in1d → np.isin for NumPy 2 compatibility
- tree.py: removed raxml_success() and its call; cosmetic cleanup
- cmt2tree.py: new utility script for -y makedb arg
